### PR TITLE
LoggingExtensions - Added New Rhinobyte.Extensions.Logging.csproj Project

### DIFF
--- a/Rhinobyte.Extensions.sln
+++ b/Rhinobyte.Extensions.sln
@@ -61,6 +61,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{3BB3D502-2
 		docs\todo-list.md = docs\todo-list.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rhinobyte.Extensions.Logging", "src\Rhinobyte.Extensions.Logging\Rhinobyte.Extensions.Logging.csproj", "{136AB6AA-B866-4EF0-ABE9-DD41261798E3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rhinobyte.Extensions.Logging.Tests", "tests\Rhinobyte.Extensions.Logging.Tests\Rhinobyte.Extensions.Logging.Tests.csproj", "{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -127,6 +131,18 @@ Global
 		{2016443A-45DB-4B47-9C5B-C5F79C05BAE4}.Release|Any CPU.ActiveCfg = ReleaseTesting|Any CPU
 		{2016443A-45DB-4B47-9C5B-C5F79C05BAE4}.ReleaseTesting|Any CPU.ActiveCfg = ReleaseTesting|Any CPU
 		{2016443A-45DB-4B47-9C5B-C5F79C05BAE4}.ReleaseTesting|Any CPU.Build.0 = ReleaseTesting|Any CPU
+		{136AB6AA-B866-4EF0-ABE9-DD41261798E3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{136AB6AA-B866-4EF0-ABE9-DD41261798E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{136AB6AA-B866-4EF0-ABE9-DD41261798E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{136AB6AA-B866-4EF0-ABE9-DD41261798E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{136AB6AA-B866-4EF0-ABE9-DD41261798E3}.ReleaseTesting|Any CPU.ActiveCfg = Release|Any CPU
+		{136AB6AA-B866-4EF0-ABE9-DD41261798E3}.ReleaseTesting|Any CPU.Build.0 = Release|Any CPU
+		{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}.Release|Any CPU.ActiveCfg = ReleaseTesting|Any CPU
+		{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}.Release|Any CPU.Build.0 = ReleaseTesting|Any CPU
+		{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}.ReleaseTesting|Any CPU.ActiveCfg = ReleaseTesting|Any CPU
+		{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}.ReleaseTesting|Any CPU.Build.0 = ReleaseTesting|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -143,6 +159,8 @@ Global
 		{01A7860D-5999-4C55-80D8-70688758673E} = {40E9ED1D-0F68-494D-A657-B75A62645AD8}
 		{E6E61601-7C9F-4A53-9450-667C976A8895} = {40E9ED1D-0F68-494D-A657-B75A62645AD8}
 		{2016443A-45DB-4B47-9C5B-C5F79C05BAE4} = {40E9ED1D-0F68-494D-A657-B75A62645AD8}
+		{136AB6AA-B866-4EF0-ABE9-DD41261798E3} = {BDE5D871-F9C3-405C-9E3F-FE5DE7B26FC6}
+		{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1} = {40E9ED1D-0F68-494D-A657-B75A62645AD8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A319B09C-E5BD-4E06-94C1-6D8666961326}

--- a/devops/create-code-coverage-report
+++ b/devops/create-code-coverage-report
@@ -25,7 +25,13 @@ for (( paramIndex=1; paramIndex<=$#; paramIndex++ )); do
 done;
 
 if [ $testProjectIndex -eq 0 ]; then
-	testProjectNames=("Rhinobyte.Extensions.DataAnnotations.Tests" "Rhinobyte.Extensions.DependencyInjection.Tests" "Rhinobyte.Extensions.Reflection.Tests" "Rhinobyte.Extensions.TestTools.Tests");
+	testProjectNames=(
+		"Rhinobyte.Extensions.DataAnnotations.Tests" 
+		"Rhinobyte.Extensions.DependencyInjection.Tests" 
+		"Rhinobyte.Extensions.Logging.Tests" 
+		"Rhinobyte.Extensions.Reflection.Tests" 
+		"Rhinobyte.Extensions.TestTools.Tests"
+	);
 	testProjectsCount=${#testProjectNames[@]};
 else
 	testProjectsCount=$testProjectIndex

--- a/solution.props
+++ b/solution.props
@@ -61,6 +61,9 @@
         <DependencyInjectionPackageVersion>1.0.0</DependencyInjectionPackageVersion>
         <DependencyInjectionPackage_ConsumerDependencyVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(DependencyInjectionPackageVersion)', '(\d+\.\d+)\..+', '$1.0'))</DependencyInjectionPackage_ConsumerDependencyVersion>
 
+        <LoggingPackageVersion>1.0.0-rc.1</LoggingPackageVersion>
+        <LoggingPackage_ConsumerDependencyVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(LoggingPackageVersion)', '(\d+\.\d+)\..+', '$1.0'))</LoggingPackage_ConsumerDependencyVersion>
+
         <ReflectionPackageVersion>1.0.2</ReflectionPackageVersion>
         <ReflectionPackage_ConsumerDependencyVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(ReflectionPackageVersion)', '(\d+\.\d+)\..+', '$1.0'))</ReflectionPackage_ConsumerDependencyVersion>
 

--- a/src/Rhinobyte.Extensions.DependencyInjection/Rhinobyte.Extensions.DependencyInjection.csproj
+++ b/src/Rhinobyte.Extensions.DependencyInjection/Rhinobyte.Extensions.DependencyInjection.csproj
@@ -26,15 +26,7 @@ The IServiceCollection extension methods provide support for registering auto-di
     </PropertyGroup>
 
     <ItemGroup>
-        <!--
-            TODO: Support a wider range/lower minimum version of the Microsoft.XXX dependencies
-
-            The v5 dotnet/runtime libraries support a wide range of target frameworks but other dependencies (e.g. a lower version of EF Core) can
-            prevent consumers from being able to update to the v5 libraries. I'd prefer to set our minimum required version to the lowest possible
-            value. Some considerable though/design work may be required to ensure that our extension libraries will work at runtime with different
-            major versions of the various dependency libraries.
-        -->
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All" />
     </ItemGroup>
     

--- a/src/Rhinobyte.Extensions.Logging/ILogMessageFormatter.cs
+++ b/src/Rhinobyte.Extensions.Logging/ILogMessageFormatter.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.IO;
+
+namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// An interface representing a formatter used by the <see cref="QueueLogger{TMessageEntry}"/> to create the message entry to be enqueued.
+/// </summary>
+/// <typeparam name="TMessageEntry">The type of the message entry returned by the formatter</typeparam>
+public interface ILogMessageFormatter<TMessageEntry>
+{
+	/// <summary>
+	/// Whether or not this log message formatter neeeds the <see cref="TextWriter"/> parameter to be supplied to the <see cref="FormatEntry{TState}(in LogEntry{TState}, IExternalScopeProvider?, TextWriter?)"/> method.
+	/// <para>
+	/// Used by the <see cref="QueueLogger{TMessageEntry}"/> to determine if the loggers internally maintained thread static <see cref="StringWriter"/> needs to be initialized or can be left null.
+	/// </para>
+	/// </summary>
+	bool IsTextWriterNeeded { get; }
+
+	/// <summary>
+	/// Gets the name associated with the log message formatter.
+	/// </summary>
+	string Name { get; }
+
+	/// <summary>
+	/// Writes the formatted log message to the specified TextWriter.
+	/// </summary>
+	/// <param name="logEntry">The log entry.</param>
+	/// <param name="scopeProvider">The provider of scope data.</param>
+	/// <param name="textWriter">A text writer that is conditionally supplied. If the <see cref="IsTextWriterNeeded"/> property is false, then null is passed instead.</param>
+	/// <typeparam name="TState">The type of the object to be written.</typeparam>
+	TMessageEntry? FormatEntry<TState>(in LogEntry<TState> logEntry, IExternalScopeProvider? scopeProvider, TextWriter? textWriter);
+}
+
+
+/// <summary>
+/// An interface representing a formatter used by the <see cref="QueueLogger{TMessageEntry}"/> to create the message entry to be enqueued.
+/// /// <para>
+/// The <typeparamref name="TOptions"/> generic parameter is used to distinguish service descriptor registrations for different derived implementations of the QueueLoggerProvider and QueueLoggerOptions.
+/// </para>
+/// </summary>
+/// <typeparam name="TMessageEntry">The type of the message entry returned by the formatter</typeparam>
+/// <typeparam name="TOptions">The logger options type used to differentiate the service registrations</typeparam>
+public interface ILogMessageFormatter<TMessageEntry, TOptions> : ILogMessageFormatter<TMessageEntry>
+	where TOptions : QueueLoggerOptions
+{ }

--- a/src/Rhinobyte.Extensions.Logging/NullScope.cs
+++ b/src/Rhinobyte.Extensions.Logging/NullScope.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Rhinobyte.Extensions.Logging;
+
+/// <summary>
+/// An empty scope without any logic
+/// </summary>
+/// <remarks>
+/// It would be nice if Microsoft.Extensions.Logging exported this publicly so custom provider's don't have to duplicate it.
+/// </remarks>
+public sealed class NullScope : IDisposable
+{
+	/// <summary>
+	/// Singleton instance of the <see cref="NullScope"/> returned by loggers when scopes aren't enabled/supported
+	/// </summary>
+	public static NullScope Instance { get; } = new NullScope();
+
+	private NullScope()
+	{ }
+
+	/// <inheritdoc />
+	public void Dispose()
+	{ }
+}

--- a/src/Rhinobyte.Extensions.Logging/NullScopeProvider.cs
+++ b/src/Rhinobyte.Extensions.Logging/NullScopeProvider.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+
+namespace Rhinobyte.Extensions.Logging;
+
+/// <summary>
+/// Scope provider that does nothing.
+/// </summary>
+/// <remarks>
+/// It would be nice if Microsoft.Extensions.Logging exported this publicly so custom provider's don't have to duplicate it.
+/// </remarks>
+internal sealed class NullScopeProvider : IExternalScopeProvider
+{
+	private NullScopeProvider()
+	{
+	}
+
+	/// <summary>
+	/// Singleton instance of the <see cref="NullScopeProvider"/>
+	/// </summary>
+	public static IExternalScopeProvider Instance { get; } = new NullScopeProvider();
+
+	/// <inheritdoc />
+	void IExternalScopeProvider.ForEachScope<TState>(Action<object?, TState> callback, TState state)
+	{ }
+
+	/// <inheritdoc />
+	IDisposable IExternalScopeProvider.Push(object? state) => NullScope.Instance;
+}

--- a/src/Rhinobyte.Extensions.Logging/Queue/IAsyncLogMessageProcessor.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/IAsyncLogMessageProcessor.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// An interface representing the background processor actions used to process the log message entries from a <see cref="ILogMessageQueue{TMessageEntry}"/>
+/// <para>
+/// Implementations must implement this interface in order to be used with the <see cref="QueueLoggerProcessorType.BackgroundTask"/> processor type.
+/// </para>
+/// </summary>
+/// <typeparam name="TMessageEntry">The type of the message entry stored in the queue</typeparam>
+/// <typeparam name="TOptions">The logger options type used to differentiate the service registrations</typeparam>
+public interface IAsyncLogMessageProcessor<TMessageEntry, TOptions>
+	where TOptions : QueueLoggerOptions
+{
+	/// <summary>
+	/// Process a single <typeparamref name="TMessageEntry"/> instance from the queue
+	/// </summary>
+	Task ProcessLogMessageEntryAsync(TMessageEntry logMessageEntry, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Process a collection of <typeparamref name="TMessageEntry"/> instances from the queue
+	/// <para>
+	/// Used by the background task processor to process a batch of log message entries in a given flush interval
+	/// </para>
+	/// <para>
+	/// Also used by the background processor types to flush all remaining entries in the queue when the background processor is stopping or being disposed
+	/// </para>
+	/// </summary>
+	Task ProcessLogMessageEntriesAsync(ICollection<TMessageEntry> logMessageEntries, CancellationToken cancellationToken);
+}

--- a/src/Rhinobyte.Extensions.Logging/Queue/ILogMessageQueue.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/ILogMessageQueue.cs
@@ -1,0 +1,46 @@
+﻿namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// An interface representing a queue of log message entries to be processed separately without blocking the thread that made the logging call
+/// </summary>
+/// <typeparam name="TMessageEntry">The type of the message entry stored in the queue</typeparam>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public interface ILogMessageQueue<TMessageEntry>
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
+{
+	/// <summary>
+	/// Enqueue a message entry to be processed separately without blocking the thread that made the log call
+	/// </summary>
+	/// <param name="messageEntry">The message entry to enqueue</param>
+	void EnqueueMessage(TMessageEntry messageEntry);
+}
+
+/// <inheritdoc/>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public interface ILogMessageQueue<TMessageEntry, TOptions> : ILogMessageQueue<TMessageEntry>
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
+	where TOptions : QueueLoggerOptions
+{
+	/// <summary>
+	/// Handle the options being reloaded. Called by the QueueLoggerProvider to cut down on the number of options monitor change listener registrations needed.
+	/// </summary>
+	/// <param name="options">The reloaded options</param>
+	void HandleOptionsReload(TOptions options);
+}
+
+/// <summary>
+/// An interface for the QueueLoggerProvider to identify if the queue type is also a background processor that needs to be started and stopped.
+/// </summary>
+public interface IBackgroundProcessor
+{
+	/// <summary>
+	/// Start the background processing loop.
+	/// </summary>
+	void StartProcessing();
+
+	/// <summary>
+	/// Stop the background processing loop.
+	/// </summary>
+	/// <param name="flushRemaining">If true then the stop routine will attemmpt to process any remaining log message entries in the queue.</param>
+	void StopProcessing(bool flushRemaining);
+}

--- a/src/Rhinobyte.Extensions.Logging/Queue/ISyncLogMessageProcessor.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/ISyncLogMessageProcessor.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+
+namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// An interface representing the background processor actions used to process the log message entries from a <see cref="ILogMessageQueue{TMessageEntry}"/>
+/// <para>
+/// Implementations must implement this interface in order to be used with the <see cref="QueueLoggerProcessorType.BackgroundThread"/> processor type.
+/// </para>
+/// </summary>
+/// <typeparam name="TMessageEntry">The type of the message entry stored in the queue</typeparam>
+/// <typeparam name="TOptions">The logger options type used to differentiate the service registrations</typeparam>
+public interface ISyncLogMessageProcessor<TMessageEntry, TOptions>
+	where TOptions : QueueLoggerOptions
+{
+	/// <summary>
+	/// Process a single <typeparamref name="TMessageEntry"/> instance from the queue
+	/// </summary>
+	void ProcessLogMessageEntry(TMessageEntry logMessageEntry, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Process a collection of <typeparamref name="TMessageEntry"/> instances from the queue
+	/// <para>
+	/// Used by the background task processor to process a batch of log message entries in a given flush interval
+	/// </para>
+	/// <para>
+	/// Also used by the background processor types to flush all remaining entries in the queue when the background processor is stopping or being disposed
+	/// </para>
+	/// </summary>
+	void ProcessLogMessageEntries(ICollection<TMessageEntry> logMessageEntries, CancellationToken cancellationToken);
+}

--- a/src/Rhinobyte.Extensions.Logging/Queue/InnerLogMessageQueue.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/InnerLogMessageQueue.cs
@@ -1,0 +1,333 @@
+﻿using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// Default impelmentation of the <see cref="ILogMessageQueue{TMessageEntry, TOptions}"/>.
+/// <para>
+/// When the queue size is unbounded it uses <see cref="System.Threading.Channels.Channel"/> under the hood for the async wait and dequeue behaviors.
+/// </para>
+/// <para>
+/// When the queue size is bounded and the queue full behavior is not <see cref="QueueFullBehavior.Wait"/> it also uses <see cref="System.Threading.Channels.Channel"/>
+/// under the hood since there is no need to block during the <see cref="EnqueueMessage(TMessageEntry)"/> call.
+/// </para>
+/// <para>
+/// When the queue size is bounded and the queue full behavior is not <see cref="QueueFullBehavior.Wait"/> it uses custom <see cref="SemaphoreSlim"/> counters since
+/// the EnqueueMessage method needs to be called synchronously from the logger and the dequeue behavior can be async.
+/// </para>
+/// </summary>
+/// <typeparam name="TMessageEntry">The type of the log message entry to be stored in the queue</typeparam>
+/// <typeparam name="TOptions">The logger options type</typeparam>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+public sealed class InnerLogMessageQueue<TMessageEntry, TOptions> : ILogMessageQueue<TMessageEntry, TOptions>, IDisposable
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
+	where TOptions : QueueLoggerOptions
+{
+	private const int DefaultQueueFullWaitTimeoutThreshold = 60_000; // 1Minute
+
+	private readonly CancellationTokenSource? _consumersCancellationTokenSource;
+	private readonly ConcurrentQueue<TMessageEntry>? _boundedQueue;
+	private SemaphoreSlim? _freeNodes;
+	private bool _isDisposed;
+	private readonly Channel<TMessageEntry>? _messageChannel;
+	private readonly ChannelReader<TMessageEntry>? _messageChannelReader;
+	private readonly ChannelWriter<TMessageEntry>? _messageChannelWriter;
+	private readonly int _maxQueueSize;
+	private SemaphoreSlim? _occupiedNodes;
+	private readonly CancellationTokenSource? _producersCancellationTokenSource;
+	private readonly QueueFullBehavior _queueFullBehavior;
+	private int _queueFullWaitTimeoutThreshold;
+
+	/// <summary>
+	/// Construct the <see cref="InnerLogMessageQueue{TMessageEntry, TOptions}"/> instance.
+	/// </summary>
+	/// <remarks>
+	/// The MaxQueueSize, QueueFullBehavior, and QueueFullWaitTimeoutThreshold options are not reloadable so there isn't any need to
+	/// use IOptionsMonitor or register a reload change token listener
+	/// </remarks>
+	public InnerLogMessageQueue(
+		IOptions<TOptions> optionsMonitor)
+		: this(optionsMonitor is not null ? optionsMonitor.Value : throw new ArgumentNullException(nameof(optionsMonitor)))
+	{
+	}
+
+	internal InnerLogMessageQueue(
+		TOptions optionsValue)
+	{
+		if (optionsValue is null) throw new ArgumentNullException(nameof(optionsValue));
+
+		_maxQueueSize = optionsValue.MaxQueueSize ?? 0;
+		_queueFullBehavior = optionsValue.QueueFullBehavior;
+
+		if (_maxQueueSize > 0 && _queueFullBehavior == QueueFullBehavior.Wait)
+		{
+			// When the options are set to use bounded queue with wait-to-enqueue-when-full behavior we'll use our own counter semaphores.
+			// Done this way because the out-of-the-box solutions don't cover a mix of sync enqueue and async dequeue behavior. They are all
+			// either fully sync (BlockingCollection) or fully async (channels).
+			_boundedQueue = new ConcurrentQueue<TMessageEntry>();
+			_consumersCancellationTokenSource = new CancellationTokenSource();
+			_freeNodes = new SemaphoreSlim(_maxQueueSize);
+			_occupiedNodes = new SemaphoreSlim(0);
+			_producersCancellationTokenSource = new CancellationTokenSource();
+
+			_queueFullWaitTimeoutThreshold = optionsValue.QueueFullWaitTimeoutThreshold ?? DefaultQueueFullWaitTimeoutThreshold;
+			if (_queueFullWaitTimeoutThreshold < -1)
+				_queueFullWaitTimeoutThreshold = DefaultQueueFullWaitTimeoutThreshold;
+		}
+		else if (_maxQueueSize > 0)
+		{
+			var channelOptions = new BoundedChannelOptions(_maxQueueSize)
+			{
+				AllowSynchronousContinuations = false,
+				FullMode = GetBoundedChannelFullMode(optionsValue.QueueFullBehavior),
+				SingleReader = true
+			};
+			_messageChannel = Channel.CreateBounded<TMessageEntry>(channelOptions);
+		}
+		else
+		{
+			var channelOptions = new UnboundedChannelOptions()
+			{
+				AllowSynchronousContinuations = false,
+				SingleReader = true
+			};
+			_messageChannel = Channel.CreateUnbounded<TMessageEntry>(channelOptions);
+
+			_messageChannelReader = _messageChannel.Reader;
+			_messageChannelWriter = _messageChannel.Writer;
+		}
+	}
+
+
+	/// <summary>
+	/// Whether or not the queue has been marked as complete for adding to it.
+	/// </summary>
+	public bool IsAddingCompleted { get; private set; }
+
+
+	/// <summary>
+	/// Mark the underlying channel as done writing.
+	/// </summary>
+	public void CompleteAdding()
+	{
+		if (IsAddingCompleted)
+			return;
+
+		_consumersCancellationTokenSource?.Cancel();
+		_producersCancellationTokenSource?.Cancel();
+		if (_messageChannelWriter is not null)
+		{
+			if (_messageChannelWriter.TryComplete())
+			{
+				IsAddingCompleted = true;
+			}
+		}
+	}
+
+	private void Dispose(bool disposing)
+	{
+		if (!_isDisposed)
+		{
+			if (disposing)
+			{
+				CompleteAdding();
+				_consumersCancellationTokenSource?.Dispose();
+				_producersCancellationTokenSource?.Dispose();
+				_freeNodes?.Dispose();
+				_freeNodes = null;
+				_occupiedNodes?.Dispose();
+				_occupiedNodes = null;
+			}
+
+			_isDisposed = true;
+		}
+	}
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+
+	/// <summary>
+	/// Return the next item to consume or wait asynchronously until an item becomes available.
+	/// </summary>
+	/// <param name="cancellationToken"></param>
+	/// <returns></returns>
+	public async Task<TMessageEntry?> DequeueOrWaitAsync(CancellationToken cancellationToken)
+	{
+		if (_isDisposed)
+			throw new ObjectDisposedException(nameof(InnerLogMessageQueue<TMessageEntry, TOptions>));
+
+		if (_messageChannelReader is not null)
+			return await _messageChannelReader.ReadAsync(cancellationToken).ConfigureAwait(false);
+
+
+		Debug.Assert(_boundedQueue is not null);
+		Debug.Assert(_consumersCancellationTokenSource is not null);
+		Debug.Assert(_freeNodes is not null);
+		Debug.Assert(_occupiedNodes is not null);
+
+		using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _consumersCancellationTokenSource!.Token);
+		await _occupiedNodes!.WaitAsync(linkedCancellationTokenSource.Token).ConfigureAwait(false);
+
+		// We've already decremented the _occupiedNodes so we want to access _boundedQueue directly and not go through our own TryDequeue method which would decrement it a 2nd time
+		if (_boundedQueue!.TryDequeue(out var dequeuedItem))
+		{
+			// Update the counts
+			_ = _freeNodes!.Release();
+			return dequeuedItem;
+		}
+
+		return default;
+	}
+
+	/// <inheritdoc/>
+	public void EnqueueMessage(TMessageEntry messageEntry)
+	{
+		if (_isDisposed)
+			throw new ObjectDisposedException(nameof(InnerLogMessageQueue<TMessageEntry, TOptions>));
+
+		_ = messageEntry ?? throw new ArgumentNullException(nameof(messageEntry));
+
+		if (IsAddingCompleted)
+			return;
+
+		if (_messageChannelWriter is not null)
+		{
+			_ = _messageChannelWriter.TryWrite(messageEntry);
+			return;
+		}
+
+		Debug.Assert(_boundedQueue is not null);
+		Debug.Assert(_freeNodes is not null);
+		Debug.Assert(_occupiedNodes is not null);
+		Debug.Assert(_producersCancellationTokenSource is not null);
+		var producersCancellationToken = _producersCancellationTokenSource!.Token;
+
+		bool waitForSemaphoreWasSuccessful;
+		try
+		{
+			waitForSemaphoreWasSuccessful = _freeNodes!.Wait(0, default);
+			if (!waitForSemaphoreWasSuccessful && _queueFullWaitTimeoutThreshold > 0)
+				waitForSemaphoreWasSuccessful = _freeNodes.Wait(_queueFullWaitTimeoutThreshold, producersCancellationToken);
+		}
+		catch (OperationCanceledException)
+		{
+			// CompleteAdding was called, nothing else to do here
+			return;
+		}
+
+		if (!waitForSemaphoreWasSuccessful)
+			return;
+
+		try
+		{
+			producersCancellationToken.ThrowIfCancellationRequested();
+			_boundedQueue!.Enqueue(messageEntry);
+			_ = _occupiedNodes!.Release();
+		}
+		catch (OperationCanceledException)
+		{
+			// Increment freeNodes back up by one since we failed to enqueue anything
+			_ = _freeNodes.Release();
+			return;
+		}
+		catch
+		{
+			_ = _freeNodes.Release();
+			throw;
+		}
+	}
+
+	/// <summary>
+	/// Map the <paramref name="queueFullBehavior"/> to the corresponding <see cref="BoundedChannelFullMode"/> value
+	/// </summary>
+	internal static BoundedChannelFullMode GetBoundedChannelFullMode(QueueFullBehavior queueFullBehavior)
+	{
+		switch (queueFullBehavior)
+		{
+			case QueueFullBehavior.DropNewest:
+				return BoundedChannelFullMode.DropNewest;
+
+			case QueueFullBehavior.DropOldest:
+				return BoundedChannelFullMode.DropOldest;
+
+			case QueueFullBehavior.Wait:
+				return BoundedChannelFullMode.Wait;
+
+			case QueueFullBehavior.DontQueue:
+			default:
+				return BoundedChannelFullMode.DropWrite;
+		}
+	}
+
+	/// <summary>
+	/// Helper function to measure and calculate the remaining milliseconds until timeout
+	/// </summary>
+	internal static int GetRemainingTimeout(uint startTime, int originalWaitMillisecondsTimeout)
+	{
+		var elapsedMilliseconds = (((uint)Environment.TickCount) - startTime);
+		if (elapsedMilliseconds > int.MaxValue)
+			return 0;
+
+		var remainingTimeoutThreshold = originalWaitMillisecondsTimeout - (int)elapsedMilliseconds;
+		if (remainingTimeoutThreshold <= 0)
+			return 0;
+
+		return remainingTimeoutThreshold;
+	}
+
+	/// <summary>
+	/// Handle the options being reloaded. Called directly by the QueueLoggerProvider to cut down on the number of options monitor change listener registrations needed.
+	/// </summary>
+	/// <param name="options">The reloaded options</param>
+	public void HandleOptionsReload(TOptions options)
+	{
+		if (options is null)
+			return;
+
+		// QueueFullBehavior and MaxQueueSize do not support reloading at this time
+
+		var queueFullWaitTimeoutThreshold = options.QueueFullWaitTimeoutThreshold ?? DefaultQueueFullWaitTimeoutThreshold;
+		if (queueFullWaitTimeoutThreshold < -1)
+			queueFullWaitTimeoutThreshold = DefaultQueueFullWaitTimeoutThreshold;
+
+		_queueFullWaitTimeoutThreshold = queueFullWaitTimeoutThreshold;
+	}
+
+	/// <summary>
+	/// Try to dequeue an item
+	/// </summary>
+#if !NET48 && !NETSTANDARD2_0
+	public bool TryDequeue([System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out TMessageEntry? item)
+#else
+	public bool TryDequeue(out TMessageEntry? item)
+#endif
+	{
+		if (_messageChannelReader is not null)
+		{
+			return _messageChannelReader.TryRead(out item);
+		}
+
+		Debug.Assert(_boundedQueue is not null);
+
+		var didDequeue = _boundedQueue!.TryDequeue(out item);
+		if (didDequeue)
+		{
+			// Update the counts
+			_ = _freeNodes?.Release();
+			_ = _occupiedNodes?.Wait(0, default);
+		}
+
+		return didDequeue;
+	}
+}

--- a/src/Rhinobyte.Extensions.Logging/Queue/QueueFullBehavior.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/QueueFullBehavior.cs
@@ -1,0 +1,42 @@
+﻿using System.Threading.Channels;
+
+namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// The behavior to use when <see cref="ILogMessageQueue{TMessageEntry}.EnqueueMessage(TMessageEntry)"/> is called and the queue has already reached the <see cref="QueueLoggerOptions.MaxQueueSize" />
+/// </summary>
+public enum QueueFullBehavior
+{
+	/// <summary>
+	/// When the queue is full additional items will be ignored.
+	/// <para>
+	/// Equivalent to the <see cref="BoundedChannelFullMode.DropWrite"/> value
+	/// </para>
+	/// </summary>
+	DontQueue = 0,
+
+	/// <summary>
+	/// Summary when the queue is full remove and ignore the newest item to make room for the item being written.
+	/// <para>
+	/// Equivalent to the <see cref="BoundedChannelFullMode.DropNewest"/> value
+	/// </para>
+	/// </summary>
+	DropNewest = 1,
+
+	/// <summary>
+	/// Summary when the queue is full remove and ignore the newest item to make room for the item being written.
+	/// <para>
+	/// Equivalent to the <see cref="BoundedChannelFullMode.DropOldest"/> value
+	/// </para>
+	/// </summary>
+	DropOldest = 2,
+
+	/// <summary>
+	/// When the queue is full the call to <see cref="ILogMessageQueue{TMessageEntry}.EnqueueMessage(TMessageEntry)"/> will try to block until space
+	/// is available or the <see cref="QueueLoggerOptions.QueueFullWaitTimeoutThreshold"/> is reached.
+	/// <para>
+	/// Equivalent to the <see cref="BoundedChannelFullMode.Wait"/> value
+	/// </para>
+	/// </summary>
+	Wait = 3
+}

--- a/src/Rhinobyte.Extensions.Logging/Queue/QueueLogger.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/QueueLogger.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.IO;
+
+namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// Queue logger abstract base class used to format and enqueue log message entries for deferred processing
+/// </summary>
+/// <typeparam name="TMessageEntry">The type of message entry that will be enqueued by this logger</typeparam>
+public class QueueLogger<TMessageEntry> : ILogger
+{
+	private readonly string _categoryName;
+	private readonly ILogMessageQueue<TMessageEntry> _messageQueue;
+
+	[ThreadStatic]
+	private static StringWriter? _threadStaticStringWriter;
+
+	/// <summary>
+	/// Construct a queue logger instance.
+	/// </summary>
+	public QueueLogger(
+		string categoryName,
+		ILogMessageFormatter<TMessageEntry> logMessageFormatter,
+		ILogMessageQueue<TMessageEntry> messageQueue,
+		IExternalScopeProvider scopeProvider)
+	{
+		_categoryName = categoryName ?? throw new ArgumentNullException(nameof(categoryName));
+		LogMessageFormatter = logMessageFormatter ?? throw new ArgumentNullException(nameof(logMessageFormatter));
+		_messageQueue = messageQueue ?? throw new ArgumentNullException(nameof(messageQueue));
+		ScopeProvider = scopeProvider; // Null scope provider allowed
+	}
+
+	internal ILogMessageFormatter<TMessageEntry> LogMessageFormatter { get; set; }
+	internal IExternalScopeProvider ScopeProvider { get; set; }
+
+	/// <inheritdoc/>
+	public IDisposable BeginScope<TState>(TState state) => ScopeProvider?.Push(state) ?? NullScope.Instance;
+
+	/// <inheritdoc/>
+	public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+	/// <summary>
+	/// Constructs a log message entry using the configured <see cref="LogMessageFormatter"/> and enqueue 
+	/// </summary>
+	/// <typeparam name="TState"></typeparam>
+	/// <param name="logLevel"></param>
+	/// <param name="eventId"></param>
+	/// <param name="state"></param>
+	/// <param name="exception"></param>
+	/// <param name="formatter"></param>
+	/// <exception cref="ArgumentNullException"></exception>
+	public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+	{
+		if (!IsEnabled(logLevel))
+			return;
+
+		_ = formatter ?? throw new ArgumentNullException(nameof(formatter));
+
+		var logEntry = new LogEntry<TState>(logLevel, _categoryName, eventId, state, exception, formatter);
+
+		TMessageEntry? messageEntry;
+		if (!LogMessageFormatter.IsTextWriterNeeded)
+		{
+			messageEntry = LogMessageFormatter.FormatEntry(logEntry, ScopeProvider, null);
+		}
+		else
+		{
+			_threadStaticStringWriter ??= new StringWriter();
+			messageEntry = LogMessageFormatter.FormatEntry(logEntry, ScopeProvider, _threadStaticStringWriter);
+		}
+
+		if (messageEntry is not null)
+			_messageQueue.EnqueueMessage(messageEntry);
+
+		if (_threadStaticStringWriter is not null)
+		{
+			var stringBuilder = _threadStaticStringWriter.GetStringBuilder();
+			_ = stringBuilder.Clear();
+
+			var capacityResetValue = LogMessageFormatter.IsTextWriterNeeded ? 1024 : 0;
+			if (stringBuilder.Capacity > capacityResetValue)
+				stringBuilder.Capacity = capacityResetValue;
+		}
+	}
+}

--- a/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerBackgroundServiceProcessor.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerBackgroundServiceProcessor.cs
@@ -1,0 +1,137 @@
+﻿// TODO: Decide if there's any value in including a hosted background service processor type like this...
+// If so do we want to put it in this library and add a dependency to Microsoft.Extensions.Hosting.Abstractions or put it in a separate library to limit dependenices...
+
+//using Microsoft.Extensions.Options;
+//using System;
+//using System.Collections.Generic;
+//using System.Text;
+
+//namespace Rhinobyte.Extensions.Logging.Queue;
+
+//public class QueueLoggerBackgroundServiceProcessor<TMessageEntry, TOptions> : BackgroundService, ILogMessageQueue<TMessageEntry, TOptions>, IDisposable
+//	where TOptions : QueueLoggerOptions
+//{
+//	private bool isDisposed;
+//	private readonly ILogMessageProcessor<TMessageEntry, TOptions> _logMessageProcessor;
+//	private readonly InnerLogMessageQueue<TMessageEntry, TOptions> _messageQueue;
+//	private readonly IOptionsMonitor<TOptions> _optionsMonitor;
+//	private readonly IDisposable _optionsReloadToken;
+
+//	public QueueLoggerBackgroundServiceProcessor(
+//		ILogMessageProcessor<TMessageEntry, TOptions> logMessageProcessor,
+//		InnerLogMessageQueue<TMessageEntry, TOptions> messageQueue,
+//		IOptionsMonitor<TOptions> optionsMonitor)
+//	{
+//		_ = logMessageProcessor ?? throw new ArgumentNullException(nameof(logMessageProcessor));
+//		_ = messageQueue ?? throw new ArgumentNullException(nameof(messageQueue));
+
+//		if (optionsMonitor is null) throw new ArgumentNullException(nameof(optionsMonitor));
+//		if (optionsMonitor.CurrentValue is null) throw new ArgumentException($"{nameof(optionsMonitor)}.{nameof(optionsMonitor.CurrentValue)} is null");
+//		_optionsMonitor = optionsMonitor;
+
+//		ReloadLoggerOptions(_optionsMonitor.CurrentValue);
+//		_optionsReloadToken = _optionsMonitor.OnChange(ReloadLoggerOptions);
+//	}
+
+//	/// <summary>
+//	/// Overridable cleanup code method for the standard dispose pattern.
+//	/// </summary>
+//	protected virtual void Dispose(bool disposing)
+//	{
+//		if (!isDisposed)
+//		{
+//			if (disposing)
+//			{
+//				// TODO: dispose managed state (managed objects)
+//			}
+
+//			isDisposed = true;
+//		}
+//	}
+
+//	/// <inheritdoc />
+//	public void Dispose()
+//	{
+//		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+//		Dispose(disposing: true);
+//		GC.SuppressFinalize(this);
+//	}
+
+///// <summary>
+///// Handle the options being reloaded. Called by the QueueLoggerProvider to cut down on the number of options monitor change listener registrations needed.
+///// </summary>
+///// <param name="options">The reloaded options</param>
+//public void HandleOptionsReload(TOptions options)
+//{
+//	if (options is null)
+//		return;
+
+//	_batchSize = options.BackgroundProcessorBatchSize > 0
+//		? options.BackgroundProcessorBatchSize.Value
+//		: null;
+
+//	_loopDelayInterval = options.BackgroundProcessorLoopDelayInterval > TimeSpan.Zero
+//		? (int)options.BackgroundProcessorLoopDelayInterval.Value.TotalMilliseconds
+//		: null;
+
+//	_processRemainingTimeoutThreshold = options.ProcessRemainingTimeoutThreshold > TimeSpan.Zero
+//		? options.ProcessRemainingTimeoutThreshold.Value
+//		: TimeSpan.FromSeconds(60);
+
+//	// Call ReloadLoggerOptions on the wrapped InnerLogMessageQueue as well
+//	_messageQueue.HandleOptionsReload(options);
+//}
+
+//protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+//{
+//while (!stoppingToken!.IsCancellationRequested)
+//{
+//	try
+//	{
+//		if (_loopDelayInterval is not null)
+//			await Task.Delay(_loopDelayInterval.Value, stoppingToken).ConfigureAwait(false);
+
+//		if (_cancellationTokenSource.IsCancellationRequested)
+//			return;
+
+//		var message = await _messageQueue.DequeueOrWaitAsync(stoppingToken).ConfigureAwait(false);
+//		if (message is null)
+//			continue;
+
+//		if (_batchSize is null)
+//		{
+//			await _logMessageProcessor.ProcessLogMessageEntryAsync(message, stoppingToken).ConfigureAwait(false);
+//			continue;
+//		}
+
+//		_currentBatch.Add(message);
+//		var limit = _batchSize;
+//		while (limit > 0 && _messageQueue!.TryDequeue(out message))
+//		{
+//			_currentBatch.Add(message!);
+//			--limit;
+//		}
+
+//		try
+//		{
+//			await _logMessageProcessor.ProcessLogMessageEntriesAsync(_currentBatch, stoppingToken).ConfigureAwait(false);
+//		}
+//#pragma warning disable CA1031 // Do not catch general exception types
+//		catch (Exception exc)
+//#pragma warning restore CA1031 // Do not catch general exception types
+//		{
+//			Debug.Write(exc);
+//		}
+
+//		_currentBatch.Clear();
+//	}
+//#pragma warning disable CA1031 // Do not catch general exception types
+//	catch (Exception exc)
+//#pragma warning restore CA1031 // Do not catch general exception types
+//	{
+//		Debug.Write(exc);
+//	}
+//}
+//}
+
+

--- a/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerBackgroundTaskProcessor.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerBackgroundTaskProcessor.cs
@@ -1,0 +1,301 @@
+﻿using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// An implementation of the ILogMessageQueue that internally handles processing of the log message queue using a background task started via <see cref="Task.Run(Action)"/>
+/// </summary>
+/// <typeparam name="TMessageEntry">The log message entry type</typeparam>
+/// <typeparam name="TOptions">The logger options type</typeparam>
+public class QueueLoggerBackgroundTaskProcessor<TMessageEntry, TOptions> : ILogMessageQueue<TMessageEntry, TOptions>, IBackgroundProcessor, IDisposable
+	where TOptions : QueueLoggerOptions
+{
+	private int? _batchSize;
+	private CancellationTokenSource? _cancellationTokenSource;
+	private readonly List<TMessageEntry> _currentBatch = new List<TMessageEntry>();
+	private bool _isDisposed;
+	private readonly IAsyncLogMessageProcessor<TMessageEntry, TOptions> _logMessageProcessor;
+	private int? _loopDelayInterval;
+	private readonly InnerLogMessageQueue<TMessageEntry, TOptions> _messageQueue;
+	private TimeSpan _processRemainingTimeoutThreshold;
+	private Task? _processQueueTask;
+
+	/// <summary>
+	/// Intantiate a new instance of the QueueLoggerBackgroundTaskProcessor.
+	/// </summary>
+	public QueueLoggerBackgroundTaskProcessor(
+		IAsyncLogMessageProcessor<TMessageEntry, TOptions> logMessageProcessor,
+		IOptions<TOptions> options)
+	{
+		_logMessageProcessor = logMessageProcessor ?? throw new ArgumentNullException(nameof(logMessageProcessor));
+
+		if (options is null) throw new ArgumentNullException(nameof(options));
+		if (options.Value is null) throw new ArgumentException($"{nameof(options)}.{nameof(options.Value)} is null");
+
+		_messageQueue = new InnerLogMessageQueue<TMessageEntry, TOptions>(options.Value);
+
+		HandleOptionsReload(options.Value);
+	}
+
+	/// <summary>
+	/// True if the processor background task is active, false otherwise.
+	/// </summary>
+	public bool IsProcessing { get; private set; }
+
+	/// <summary>
+	/// Overridable cleanup code method for the standard dispose pattern.
+	/// </summary>
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!_isDisposed)
+		{
+			if (disposing)
+			{
+				if (IsProcessing)
+					StopProcessing(true);
+
+				_cancellationTokenSource?.Dispose();
+				_cancellationTokenSource = null;
+				_messageQueue.Dispose();
+				_processQueueTask?.Dispose();
+				_processQueueTask = null;
+			}
+
+			_isDisposed = true;
+		}
+	}
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+
+	/// <summary>
+	/// Enqueue the message entry into queue to be processed by the background task.
+	/// </summary>
+	/// <remarks>
+	/// Does not enqueue the message entry if the <see cref="BlockingCollection{T}"/> backing field is null or has <see cref="BlockingCollection{T}.IsAddingCompleted"/> signaled.
+	/// </remarks>
+	/// <param name="messageEntry">The log message entry to enqueue</param>
+	/// <exception cref="ObjectDisposedException"></exception>
+	public void EnqueueMessage(TMessageEntry messageEntry)
+	{
+		// If the queue isn't active, ignore the message
+		if (_messageQueue is not null && !_messageQueue.IsAddingCompleted)
+		{
+			try
+			{
+				_messageQueue.EnqueueMessage(messageEntry);
+				return;
+			}
+#pragma warning disable CA1031 // Do not catch general exception types
+			catch (Exception exc)
+#pragma warning restore CA1031 // Do not catch general exception types
+			{
+				Debug.Write(exc);
+			}
+		}
+
+		try
+		{
+			if (_logMessageProcessor is ISyncLogMessageProcessor<TMessageEntry, TOptions> syncLogMessageProcessor)
+				syncLogMessageProcessor.ProcessLogMessageEntry(messageEntry, default);
+		}
+#pragma warning disable CA1031 // Do not catch general exception types
+		catch (Exception exc)
+#pragma warning restore CA1031 // Do not catch general exception types
+		{
+			Debug.Write(exc);
+		}
+	}
+
+	/// <summary>
+	/// Handle the options being reloaded. Called by the QueueLoggerProvider to cut down on the number of options monitor change listener registrations needed.
+	/// </summary>
+	/// <param name="options">The reloaded options</param>
+	public void HandleOptionsReload(TOptions options)
+	{
+		if (options is null)
+			return;
+
+		_batchSize = options.BackgroundProcessorBatchSize > 0
+			? options.BackgroundProcessorBatchSize.Value
+			: null;
+
+		_loopDelayInterval = options.BackgroundProcessorLoopDelayInterval > TimeSpan.Zero
+			? (int)options.BackgroundProcessorLoopDelayInterval.Value.TotalMilliseconds
+			: null;
+
+		_processRemainingTimeoutThreshold = options.ProcessRemainingTimeoutThreshold > TimeSpan.Zero
+			? options.ProcessRemainingTimeoutThreshold.Value
+			: TimeSpan.FromSeconds(60);
+
+		// Call ReloadLoggerOptions on the wrapped InnerLogMessageQueue as well
+		_messageQueue.HandleOptionsReload(options);
+	}
+
+	private async Task ProcessMessageQueueAsync()
+	{
+		Debug.Assert(_cancellationTokenSource is not null);
+
+		var cancellationToken = _cancellationTokenSource!.Token;
+		while (!cancellationToken.IsCancellationRequested)
+		{
+			try
+			{
+				if (_loopDelayInterval is not null)
+					await Task.Delay(_loopDelayInterval.Value, cancellationToken).ConfigureAwait(false);
+
+				if (cancellationToken.IsCancellationRequested)
+					return;
+
+				var message = await _messageQueue.DequeueOrWaitAsync(cancellationToken).ConfigureAwait(false);
+				if (message is null)
+					continue;
+
+				if (_batchSize is null)
+				{
+					await _logMessageProcessor.ProcessLogMessageEntryAsync(message, cancellationToken).ConfigureAwait(false);
+					continue;
+				}
+
+				_currentBatch.Add(message);
+				var limit = _batchSize;
+				while (limit > 0 && _messageQueue!.TryDequeue(out message))
+				{
+					_currentBatch.Add(message!);
+					--limit;
+				}
+
+				await _logMessageProcessor.ProcessLogMessageEntriesAsync(_currentBatch, cancellationToken).ConfigureAwait(false);
+				_currentBatch.Clear();
+			}
+#pragma warning disable CA1031 // Do not catch general exception types
+			catch (Exception exc)
+#pragma warning restore CA1031 // Do not catch general exception types
+			{
+				Debug.Write(exc);
+				if (_batchSize is not null)
+					_currentBatch.Clear();
+			}
+		}
+	}
+
+	/// <summary>
+	/// Initializes the necessary state and starts the background processing task using <see cref="Task.Run(Action)"/>
+	/// </summary>
+	/// <exception cref="ObjectDisposedException"></exception>
+	public void StartProcessing()
+	{
+		if (_isDisposed)
+			throw new ObjectDisposedException(this.GetType().Name);
+
+		if (IsProcessing || _processQueueTask is not null)
+			return;
+
+		_cancellationTokenSource ??= new CancellationTokenSource();
+
+		// TODO: Is it better to use Task.Run() here or to directly call the async method?
+		_processQueueTask = Task.Run(ProcessMessageQueueAsync, _cancellationTokenSource.Token);
+
+		IsProcessing = true;
+	}
+
+	/// <summary>
+	/// Signales the stateful members to stop processing and disposes the stateful fields.
+	/// </summary>
+	/// <param name="flushRemaining">When true is passed the stop processing method will attempt to call the <see cref="TryFlushRemaining"/> method to process the remaining log message entries in the queue</param>
+	/// <exception cref="ObjectDisposedException"></exception>
+	public void StopProcessing(bool flushRemaining)
+	{
+		if (_isDisposed)
+			return;
+
+		if (!IsProcessing || _processQueueTask is null)
+			return;
+
+		_messageQueue!.CompleteAdding();
+
+		_cancellationTokenSource!.Cancel();
+
+		try
+		{
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+			if (!_processQueueTask.IsCompleted)
+				_ = _processQueueTask.Wait(_loopDelayInterval ?? 1500);
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+		}
+		catch (OperationCanceledException)
+		{ }
+		catch (AggregateException ex) when (ex.InnerExceptions.Count == 1 && ex.InnerExceptions[0] is TaskCanceledException)
+		{
+		}
+
+		try
+		{
+			//if (flushRemaining && !_messageQueue.IsAddingCompleted)
+			if (flushRemaining)
+				Task.Run(TryFlushRemaining).ConfigureAwait(false).GetAwaiter().GetResult();
+		}
+#pragma warning disable CA1031 // Do not catch general exception types
+		catch (Exception exc)
+#pragma warning restore CA1031 // Do not catch general exception types
+		{
+			Debug.WriteLine(exc);
+		}
+
+		try
+		{
+			_cancellationTokenSource.Dispose();
+			_cancellationTokenSource = null;
+			_messageQueue.Dispose();
+			//_messageQueue = null;
+			_processQueueTask.Dispose();
+			_processQueueTask = null;
+		}
+#pragma warning disable CA1031 // Do not catch general exception types
+		catch (Exception exc)
+#pragma warning restore CA1031 // Do not catch general exception types
+		{
+			Debug.Write(exc);
+		}
+
+		IsProcessing = false;
+	}
+
+	private async Task TryFlushRemaining()
+	{
+		var limit = _batchSize;
+		while (limit > 0 && _messageQueue!.TryDequeue(out var message))
+		{
+			_currentBatch.Add(message!);
+			--limit;
+		}
+
+		if (_currentBatch.Count < 1)
+			return;
+
+		try
+		{
+			using var timeoutCancellationTokenSource = new CancellationTokenSource(_processRemainingTimeoutThreshold);
+			await _logMessageProcessor.ProcessLogMessageEntriesAsync(_currentBatch, timeoutCancellationTokenSource.Token).ConfigureAwait(false);
+		}
+#pragma warning disable CA1031 // Do not catch general exception types
+		catch (Exception exc)
+#pragma warning restore CA1031 // Do not catch general exception types
+		{
+			Debug.Write(exc);
+		}
+
+		_currentBatch.Clear();
+	}
+}

--- a/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerBackgroundThreadProcessor.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerBackgroundThreadProcessor.cs
@@ -1,0 +1,216 @@
+﻿using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// An implementation of the ILogMessageQueue that internally handles processing of the log message queue using a background task started via <see cref="Task.Run(Action)"/>
+/// </summary>
+/// <typeparam name="TMessageEntry">The log message entry type</typeparam>
+/// <typeparam name="TOptions">The logger options type</typeparam>
+public class QueueLoggerBackgroundThreadProcessor<TMessageEntry, TOptions> : ILogMessageQueue<TMessageEntry, TOptions>, IDisposable
+	where TOptions : QueueLoggerOptions
+{
+	private int? _batchSize;
+	private readonly CancellationTokenSource _cancellationTokenSource;
+	private readonly List<TMessageEntry> _currentBatch = new List<TMessageEntry>();
+	private bool _isDisposed;
+	private readonly ISyncLogMessageProcessor<TMessageEntry, TOptions> _logMessageProcessor;
+	private readonly BlockingCollection<TMessageEntry> _messageQueue;
+	private TimeSpan _processRemainingTimeoutThreshold;
+	private readonly Thread _processQueueThread;
+
+	/// <summary>
+	/// Intantiate a new instance of the QueueLoggerBackgroundTaskProcessor.
+	/// </summary>
+	public QueueLoggerBackgroundThreadProcessor(
+		ISyncLogMessageProcessor<TMessageEntry, TOptions> logMessageProcessor,
+		IOptions<TOptions> options)
+	{
+		_logMessageProcessor = logMessageProcessor ?? throw new ArgumentNullException(nameof(logMessageProcessor));
+
+		if (options is null) throw new ArgumentNullException(nameof(options));
+		if (options.Value is null) throw new ArgumentException($"{nameof(options)}.{nameof(options.Value)} is null");
+
+		_cancellationTokenSource = new CancellationTokenSource();
+		_messageQueue = new BlockingCollection<TMessageEntry>(options.Value.MaxQueueSize ?? 1024);
+
+		HandleOptionsReload(options.Value);
+
+		_processQueueThread = new Thread(ProcessMessageQueue)
+		{
+			IsBackground = true,
+			Name = "Console logger queue processing thread"
+		};
+		_processQueueThread.Start();
+	}
+
+	/// <summary>
+	/// Overridable cleanup code method for the standard dispose pattern.
+	/// </summary>
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!_isDisposed)
+		{
+			if (disposing)
+			{
+				_cancellationTokenSource.Cancel();
+				_messageQueue.CompleteAdding();
+
+				try
+				{
+					_ = _processQueueThread.Join(1500);
+				}
+				catch (ThreadStateException)
+				{ /* Ignored */ }
+
+				TryFlushRemaining();
+
+				_cancellationTokenSource.Dispose();
+				_messageQueue?.Dispose();
+			}
+
+			_isDisposed = true;
+		}
+	}
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+
+	/// <summary>
+	/// Enqueue the message entry into queue to be processed by the background task.
+	/// </summary>
+	/// <remarks>
+	/// Does not enqueue the message entry if the <see cref="BlockingCollection{T}"/> backing field is null or has <see cref="BlockingCollection{T}.IsAddingCompleted"/> signaled.
+	/// </remarks>
+	/// <param name="messageEntry">The log message entry to enqueue</param>
+	/// <exception cref="ObjectDisposedException"></exception>
+	public void EnqueueMessage(TMessageEntry messageEntry)
+	{
+		// If the queue isn't active, ignore the message
+		if (!_messageQueue.IsAddingCompleted)
+		{
+			try
+			{
+				_messageQueue.Add(messageEntry);
+			}
+#pragma warning disable CA1031 // Do not catch general exception types
+			catch (InvalidOperationException exc)
+#pragma warning restore CA1031 // Do not catch general exception types
+			{
+				Debug.Write(exc);
+			}
+		}
+
+		try
+		{
+			_logMessageProcessor.ProcessLogMessageEntry(messageEntry, default);
+		}
+#pragma warning disable CA1031 // Do not catch general exception types
+		catch (Exception exc)
+#pragma warning restore CA1031 // Do not catch general exception types
+		{
+			Debug.Write(exc);
+		}
+	}
+
+	/// <summary>
+	/// Handle the options being reloaded. Called by the QueueLoggerProvider to cut down on the number of options monitor change listener registrations needed.
+	/// </summary>
+	/// <param name="options">The reloaded options</param>
+	public void HandleOptionsReload(TOptions options)
+	{
+		if (options is null)
+			return;
+
+		_batchSize = options.BackgroundProcessorBatchSize > 0
+			? options.BackgroundProcessorBatchSize.Value
+			: null;
+
+		_processRemainingTimeoutThreshold = options.ProcessRemainingTimeoutThreshold > TimeSpan.Zero
+			? options.ProcessRemainingTimeoutThreshold.Value
+			: TimeSpan.FromSeconds(60);
+	}
+
+	private void ProcessMessageQueue()
+	{
+		Debug.Assert(_cancellationTokenSource is not null);
+
+		while (!_cancellationTokenSource!.IsCancellationRequested)
+		{
+			try
+			{
+				if (_cancellationTokenSource.IsCancellationRequested)
+					return;
+
+				if (!_messageQueue.TryTake(out var message, Timeout.Infinite, _cancellationTokenSource.Token) || message is null)
+					continue;
+
+				if (_batchSize is null)
+				{
+					_logMessageProcessor.ProcessLogMessageEntry(message, _cancellationTokenSource.Token);
+					continue;
+				}
+
+				_currentBatch.Add(message);
+				var limit = _batchSize;
+				while (limit > 0 && _messageQueue!.TryTake(out message))
+				{
+					_currentBatch.Add(message!);
+					--limit;
+				}
+
+				_logMessageProcessor.ProcessLogMessageEntries(_currentBatch, _cancellationTokenSource.Token);
+				_currentBatch.Clear();
+			}
+#pragma warning disable CA1031 // Do not catch general exception types
+			catch (Exception exc)
+#pragma warning restore CA1031 // Do not catch general exception types
+			{
+				Debug.Write(exc);
+				if (_batchSize is not null)
+					_currentBatch.Clear();
+			}
+		}
+	}
+
+	private void TryFlushRemaining()
+	{
+		try
+		{
+			if (_messageQueue.IsCompleted)
+				return;
+
+			var limit = _batchSize ?? 1024;
+			while (limit > 0 && _messageQueue!.TryTake(out var message))
+			{
+				_currentBatch.Add(message!);
+				--limit;
+			}
+
+			if (_currentBatch.Count < 1)
+				return;
+
+			using var timeoutCancellationTokenSource = new CancellationTokenSource(_processRemainingTimeoutThreshold);
+			_logMessageProcessor.ProcessLogMessageEntries(_currentBatch, timeoutCancellationTokenSource.Token);
+
+			_currentBatch.Clear();
+		}
+#pragma warning disable CA1031 // Do not catch general exception types
+		catch (Exception exc)
+#pragma warning restore CA1031 // Do not catch general exception types
+		{
+			Debug.Write(exc);
+		}
+	}
+}

--- a/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerOptions.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerOptions.cs
@@ -1,0 +1,79 @@
+﻿using System;
+
+namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// Options for a <see cref="QueueLogger{TMessageEntry}"/>
+/// </summary>
+public class QueueLoggerOptions
+{
+	/// <summary>
+	/// An optional batch size of log message entries for the background processor to handle in a group.
+	/// <para>
+	/// When not null the background processor loop will attempt to dequeue log message entries until no entires are available or until the batch size is reached. It will then pass the entire
+	/// batch collection of log message entries to the <see cref="IAsyncLogMessageProcessor{TMessageEntry, TOptions}.ProcessLogMessageEntriesAsync(System.Collections.Generic.ICollection{TMessageEntry}, System.Threading.CancellationToken)"/>
+	/// method as a single call.
+	/// </para>
+	/// <para>
+	/// This option is generally intended to be used in conjunction with the optional <see cref="BackgroundProcessorLoopDelayInterval"/> value in order to process batches at fixed intervals.
+	/// </para>
+	/// </summary>
+	public int? BackgroundProcessorBatchSize { get; set; }
+
+	/// <summary>
+	/// An optional delay interval between iterations of the background processing loop.
+	/// <para>
+	/// When not null the background processor loop will delay for the specified interval before the next attempt to wait on the async try dequeue method.
+	/// </para>
+	/// <para>
+	/// This option is generally intended to be used in conjunction with the optional <see cref="BackgroundProcessorBatchSize"/> option in order to process batches of log message entries at fixed intervals instead of
+	/// continuously processing items as they become available. 
+	/// </para>
+	/// <para>
+	/// This option will be ignored if using the <see cref="QueueLoggerProcessorType.BackgroundThread"/> processor type.
+	/// </para>
+	/// </summary>
+	public TimeSpan? BackgroundProcessorLoopDelayInterval { get; set; }
+
+	/// <summary>
+	/// Name of the log message formatter to use.
+	/// </summary>
+	public string? FormatterName { get; set; }
+
+	/// <summary>
+	/// An optional value indicating the maximum upper bound of log message entries that can be held in the log message queue.
+	/// <para>
+	/// When not null the <see cref="QueueFullBehavior"/> will be used to determine how <see cref="ILogMessageQueue{TMessageEntry}.EnqueueMessage(TMessageEntry)"/> behaves if the queue has reached the max queue size.
+	/// </para>
+	/// <para>
+	/// <strong>IMPORTANT NOTE:</strong> This option can only be specified at the time of the initial logging provider setup. Configuration reload changes will be ignored for this option.
+	/// </para>
+	/// </summary>
+	/// <remarks>
+	/// A value less than one will be ignored and treated as if the property is null.
+	/// </remarks>
+	public int? MaxQueueSize { get; set; }
+
+	/// <summary>
+	/// The timeout threshold allowed for the background processor types to attempt processing any remaining log message entries from the queue when the background prcoess or is stopping or being disposed.
+	/// </summary>
+	public TimeSpan? ProcessRemainingTimeoutThreshold { get; set; }
+
+	/// <summary>
+	/// The behavior that will be applied when <see cref="MaxQueueSize"/> is not null and the max queue size has been reached.
+	/// <para>
+	/// <strong>IMPORTANT NOTE:</strong> This option can only be specified at the time of the initial logging provider setup. Configuration reload changes will be ignored for this option.
+	/// </para>
+	/// </summary>
+	public QueueFullBehavior QueueFullBehavior { get; set; }
+
+	/// <summary>
+	/// Because the <see cref="ILogMessageQueue{TMessageEntry}.EnqueueMessage(TMessageEntry)"/> must be synchronous to be used
+	/// in the ILogger.Log method we have to block the thread ourselves when using a bounded queue and the <see cref="QueueFullBehavior.Wait"/> option.
+	/// In such a scenario this value is is used to specify the maximum time in milliseconds to wait to enqueue the message.
+	/// <para>
+	/// A null or negative value will be ignored and a default wait of 1 minute will be used instead.
+	/// </para>
+	/// </summary>
+	public int? QueueFullWaitTimeoutThreshold { get; set; }
+}

--- a/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerProcessorType.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerProcessorType.cs
@@ -1,0 +1,17 @@
+﻿namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// The background processor type to use for the queue logger message entry processor.
+/// </summary>
+public enum QueueLoggerProcessorType
+{
+	/// <summary>
+	/// The message entry processor type that uses a background task.
+	/// </summary>
+	BackgroundTask = 0,
+
+	/// <summary>
+	/// The message entry processor type that uses a background thread.
+	/// </summary>
+	BackgroundThread = 1
+}

--- a/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerProvider.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerProvider.cs
@@ -1,0 +1,161 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+using System.Linq;
+
+namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// Abstract base class for custom logging providers that need to use a message queue in order to process the log messages on a separate thread without blocking the calling thread.
+/// </summary>
+/// <typeparam name="TMessageEntry">The type of the log message entry constructed by the log message formatter</typeparam>
+/// <typeparam name="TMessageFormatter">The type of the <see cref="ILogMessageFormatter{TMessageEntry}"/> used by the derived logger provider type</typeparam>
+/// <typeparam name="TOptions">The type of the <see cref="QueueLoggerOptions"/> used by the derived logger provider type</typeparam>
+public abstract class QueueLoggerProvider<TMessageEntry, TMessageFormatter, TOptions> : ILoggerProvider, ISupportExternalScope
+	where TMessageFormatter : ILogMessageFormatter<TMessageEntry>
+	where TOptions : QueueLoggerOptions
+{
+	private readonly string _defaultFormatterName;
+	private ConcurrentDictionary<string, TMessageFormatter> _formatters;
+	private bool _isDisposed;
+	private readonly ConcurrentDictionary<string, QueueLogger<TMessageEntry>> _loggers;
+	private readonly IOptionsMonitor<TOptions> _optionsMonitor;
+	private readonly ILogMessageQueue<TMessageEntry, TOptions> _messageQueue;
+	private readonly IDisposable _optionsReloadToken;
+	/// Ok to default to NullScopeProvider, the LoggerFactory will automatically set this to the LoggerFactoryScopeProvider because we implement ISupportExternalScope
+	private IExternalScopeProvider _scopeProvider = NullScopeProvider.Instance;
+
+	/// <summary>
+	/// Base constructor for a <see cref="QueueLoggerProvider{TMessageEntry, TMessageFormatter, TOptions}"/> implementation
+	/// </summary>
+	/// <param name="defaultFormatterName">The default log formatter name to use in the event the options property is null or invalid</param>
+	/// <param name="logMessageFormatters">The collection of registered log message formatters for the queue logger implementation to use</param>
+	/// <param name="optionsMonitor">The queue logger options monitor</param>
+	/// <param name="messageQueue">The message queue that the loggers will pump message entries into</param>
+	/// <exception cref="ArgumentNullException"></exception>
+	/// <exception cref="ArgumentException"></exception>
+	protected QueueLoggerProvider(
+		string defaultFormatterName,
+		IEnumerable<TMessageFormatter> logMessageFormatters,
+		IOptionsMonitor<TOptions> optionsMonitor,
+		ILogMessageQueue<TMessageEntry, TOptions> messageQueue)
+	{
+		if (optionsMonitor is null) throw new ArgumentNullException(nameof(optionsMonitor));
+		if (optionsMonitor.CurrentValue is null) throw new ArgumentException($"{nameof(optionsMonitor)}.{nameof(optionsMonitor.CurrentValue)} is null");
+		_optionsMonitor = optionsMonitor;
+
+		_messageQueue = messageQueue ?? throw new ArgumentNullException(nameof(messageQueue));
+
+		_loggers = new ConcurrentDictionary<string, QueueLogger<TMessageEntry>>();
+		_defaultFormatterName = defaultFormatterName;
+
+#if !NET5_0_OR_GREATER
+		_formatters = null!; // Nullable reference hack since the [MemberNotNull(..)] attribute isn't publicy accessible until net5.0 and higher... *sigh*
+#endif
+		SetFormatters(defaultFormatterName, logMessageFormatters);
+
+		HandleOptionsReload(_optionsMonitor.CurrentValue);
+		_optionsReloadToken = _optionsMonitor.OnChange(HandleOptionsReload);
+
+		if (_messageQueue is IBackgroundProcessor backgroundProcessorQueue)
+			backgroundProcessorQueue.StartProcessing();
+	}
+
+	/// <summary>
+	/// Gets the cached instance or create a new instance of the <see cref="QueueLogger{TMessageEntry}"/> for the requested logger <paramref name="categoryName"/>
+	/// </summary>
+	/// <returns>
+	/// The <see cref="ILogger"/> instance
+	/// </returns>
+	public ILogger CreateLogger(string categoryName)
+	{
+		var formatterName = _optionsMonitor.CurrentValue.FormatterName;
+		if (formatterName == null || !_formatters.TryGetValue(formatterName, out var logMessageFormatter))
+			logMessageFormatter = _formatters[_defaultFormatterName];
+
+		return _loggers.TryGetValue(categoryName, out var logger)
+			? logger
+			: _loggers.GetOrAdd(categoryName, new QueueLogger<TMessageEntry>(categoryName, logMessageFormatter, _messageQueue, _scopeProvider));
+	}
+
+
+	/// <summary>
+	/// Overridable cleanup code portion of the dispose pattern.
+	/// </summary>
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!_isDisposed)
+		{
+			if (disposing)
+			{
+				if (_messageQueue is IBackgroundProcessor backgroundProcessorQueue)
+					backgroundProcessorQueue.StopProcessing(true);
+
+				_optionsReloadToken?.Dispose();
+			}
+
+			_isDisposed = true;
+		}
+	}
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		Dispose(disposing: true);
+		System.GC.SuppressFinalize(this);
+	}
+
+	/// <summary>
+	/// Callback for the <see cref="OptionsMonitorExtensions.OnChange{TOptions}(IOptionsMonitor{TOptions}, Action{TOptions})"/> listener registration.
+	/// </summary>
+	/// <remarks>
+	/// warning:  ReloadLoggerOptions can be called before the constructor call has completed. Before registering the listener or calling this method, all of the stateful members this method depends on need to be initialized
+	/// </remarks>
+	protected void HandleOptionsReload(TOptions options)
+	{
+		_ = options ?? throw new ArgumentNullException(nameof(options));
+
+		if (options.FormatterName == null || !_formatters.TryGetValue(options.FormatterName, out var logMessageFormatter))
+			logMessageFormatter = _formatters[_defaultFormatterName];
+
+		foreach (var logger in _loggers)
+		{
+			logger.Value.LogMessageFormatter = logMessageFormatter;
+		}
+
+		_messageQueue.HandleOptionsReload(options);
+	}
+
+#if NET5_0_OR_GREATER
+	[MemberNotNull(nameof(_formatters))]
+#endif
+	private void SetFormatters(string defaultFormatterName, IEnumerable<TMessageFormatter> logMessageFormatters)
+	{
+		if (string.IsNullOrWhiteSpace(defaultFormatterName)) throw new ArgumentException($"{nameof(defaultFormatterName)} cannot be null or whitespace.", nameof(defaultFormatterName));
+		if (logMessageFormatters is null) throw new ArgumentNullException(nameof(logMessageFormatters));
+		if (!logMessageFormatters.Any()) throw new ArgumentException($"{nameof(logMessageFormatters)} must have at least one item", nameof(logMessageFormatters));
+
+		var formattersDictionary = new ConcurrentDictionary<string, TMessageFormatter>(StringComparer.OrdinalIgnoreCase);
+		foreach (var formatter in logMessageFormatters)
+			_ = formattersDictionary.TryAdd(formatter.Name, formatter);
+
+		if (!formattersDictionary.ContainsKey(defaultFormatterName))
+			throw new ArgumentException($"{nameof(logMessageFormatters)} must contain a formatter for the supplied default formatter name: {defaultFormatterName}");
+		_formatters = formattersDictionary;
+	}
+
+	/// <inheritdoc />
+	public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+	{
+		_scopeProvider = scopeProvider;
+
+		foreach (var logger in _loggers)
+			logger.Value.ScopeProvider = _scopeProvider;
+	}
+}

--- a/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerSetupExtensions.cs
+++ b/src/Rhinobyte.Extensions.Logging/Queue/QueueLoggerSetupExtensions.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Configuration;
+using System;
+
+namespace Rhinobyte.Extensions.Logging.Queue;
+
+/// <summary>
+/// Extension methods for the logging builder and service collection.
+/// <para>
+/// Custom providers derived from the <see cref="QueueLoggerProvider{TMessageEntry, TMessageFormatter, TOptions}"/> can re-use these to dry up their own extension methods.
+/// </para>
+/// </summary>
+public static class QueueLoggerSetupExtensions
+{
+	/// <summary>
+	/// Extension method used to register a subclass logging provider that utilizes the QueueLoggerProvider base code.
+	/// </summary>
+	public static ILoggingBuilder AddBackgroundTaskQueueProvider<TProvider, TProcessor, TMessageFormatter, TMessageEntry, TOptions>(
+		this ILoggingBuilder loggingBuilder)
+		where TProvider : QueueLoggerProvider<TMessageEntry, TMessageFormatter, TOptions>
+		where TProcessor : class, ISyncLogMessageProcessor<TMessageEntry, TOptions>
+		where TMessageFormatter : class, ILogMessageFormatter<TMessageEntry, TOptions>
+		where TOptions : QueueLoggerOptions
+	{
+		_ = loggingBuilder ?? throw new ArgumentNullException(nameof(loggingBuilder));
+
+		loggingBuilder.AddConfiguration();
+
+		loggingBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILogMessageFormatter<TMessageEntry, TOptions>, TMessageFormatter>());
+		loggingBuilder.Services.TryAddSingleton<ISyncLogMessageProcessor<TMessageEntry, TOptions>, TProcessor>();
+		loggingBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, TProvider>());
+		LoggerProviderOptions.RegisterProviderOptions<TOptions, TProvider>(loggingBuilder.Services);
+
+		return loggingBuilder;
+	}
+}

--- a/src/Rhinobyte.Extensions.Logging/README.md
+++ b/src/Rhinobyte.Extensions.Logging/README.md
@@ -1,0 +1,5 @@
+# Rhinobyte.Extensions.Logging
+
+[![NuGet version (Rhinobyte.Extensions.Logging)](https://img.shields.io/nuget/v/Rhinobyte.Extensions.Logging.svg?style=flat)](https://www.nuget.org/packages/Rhinobyte.Extensions.Logging/)
+
+This library contains extensions for .NET logging including extensible base types for custom logging providers that need to push the log messages into a queue that can be processed separately without blocking the current thread.

--- a/src/Rhinobyte.Extensions.Logging/Rhinobyte.Extensions.Logging.csproj
+++ b/src/Rhinobyte.Extensions.Logging/Rhinobyte.Extensions.Logging.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+        <Configurations>Debug;Release;ReleaseTesting</Configurations>
+
+        <!-- VERSION VALUES -->
+        <PackageVersion>$(LoggingPackageVersion)</PackageVersion>
+        <AssemblyVersion>$(PackageVersion).0</AssemblyVersion>
+        <FileVersion>$(PackageVersion).0</FileVersion>
+        <InformationalVersion>$(PackageVersion)</InformationalVersion>
+        <Version>$(PackageVersion)</Version>
+
+        <PackageId>Rhinobyte.Extensions.Logging</PackageId>
+        <AssemblyName>$(PackageId)</AssemblyName>
+        <RootNamespace>$(PackageId)</RootNamespace>
+        <Title>$(PackageId)</Title>
+        <PackageTags>logging queued_logging deferred_logging</PackageTags>
+
+        <ReleaseNotesTextFilePath>$(MSBuildProjectDirectory)\RELEASE-NOTES.txt</ReleaseNotesTextFilePath>
+        <Summary>Extensions for .NET logging including extensible base types for custom logging providers that need to push the log messages into a queue that can be processed separately without blocking the current thread</Summary>
+        <Description>
+            $(Summary)
+        </Description>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All" />
+    </ItemGroup>
+
+    <!-- Prior to netcoreapp3.1 the System.Threading.Channels package is needed -->
+    <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.1'))">
+        <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/tests/ExampleIgnoredAttributeAssembly/ExampleIgnoredAttributeAssembly.csproj
+++ b/tests/ExampleIgnoredAttributeAssembly/ExampleIgnoredAttributeAssembly.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Rhinobyte.Extensions.DependencyInjection\Rhinobyte.Extensions.DependencyInjection.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.DependencyInjection\Rhinobyte.Extensions.DependencyInjection.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/ExampleLibrary1/ExampleLibrary1.csproj
+++ b/tests/ExampleLibrary1/ExampleLibrary1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Rhinobyte.Extensions.DependencyInjection\Rhinobyte.Extensions.DependencyInjection.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.DependencyInjection\Rhinobyte.Extensions.DependencyInjection.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/Rhinobyte.Extensions.DataAnnotations.Tests/Rhinobyte.Extensions.DataAnnotations.Tests.csproj
+++ b/tests/Rhinobyte.Extensions.DataAnnotations.Tests/Rhinobyte.Extensions.DataAnnotations.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Rhinobyte.Extensions.DataAnnotations\Rhinobyte.Extensions.DataAnnotations.csproj" />
-        <ProjectReference Include="..\..\src\Rhinobyte.Extensions.Reflection\Rhinobyte.Extensions.Reflection.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.DataAnnotations\Rhinobyte.Extensions.DataAnnotations.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.Reflection\Rhinobyte.Extensions.Reflection.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/Rhinobyte.Extensions.DependencyInjection.Tests/Rhinobyte.Extensions.DependencyInjection.Tests.csproj
+++ b/tests/Rhinobyte.Extensions.DependencyInjection.Tests/Rhinobyte.Extensions.DependencyInjection.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Rhinobyte.Extensions.DependencyInjection\Rhinobyte.Extensions.DependencyInjection.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.DependencyInjection\Rhinobyte.Extensions.DependencyInjection.csproj" />
         <ProjectReference Include="..\ExampleIgnoredAttributeAssembly\ExampleIgnoredAttributeAssembly.csproj" />
         <ProjectReference Include="..\ExampleLibrary1\ExampleLibrary1.csproj" />
     </ItemGroup>

--- a/tests/Rhinobyte.Extensions.Logging.Tests/Rhinobyte.Extensions.Logging.Tests.csproj
+++ b/tests/Rhinobyte.Extensions.Logging.Tests/Rhinobyte.Extensions.Logging.Tests.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <ItemGroup>
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.Logging\Rhinobyte.Extensions.Logging.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.TestTools\Rhinobyte.Extensions.TestTools.csproj" />
+    </ItemGroup>
+</Project>

--- a/tests/Rhinobyte.Extensions.Logging.Tests/UnitTest1.cs
+++ b/tests/Rhinobyte.Extensions.Logging.Tests/UnitTest1.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Concurrent;
+
+namespace Rhinobyte.Extensions.Logging.Tests;
+
+[TestClass]
+public class UnitTest1
+{
+	[TestMethod]
+	public void TestMethod1()
+	{
+		using var loggerFactory = LoggerFactory.Create(loggingBuilder =>
+		{
+			_ = loggingBuilder.AddProvider(new LoggerProviderNoExternalScopeSupport());
+		});
+
+		var aggregateLogger = loggerFactory.CreateLogger<UnitTest1>();
+		using var someScope = aggregateLogger.BeginScope("Test Scope");
+#pragma warning disable CA1848 // Use the LoggerMessage delegates
+		aggregateLogger.LogInformation("Information logging statement");
+#pragma warning restore CA1848 // Use the LoggerMessage delegates
+	}
+}
+
+
+public class BeginScopeThrowsLogger : ILogger
+{
+	public BeginScopeThrowsLogger()
+	{
+	}
+
+	public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+	{
+	}
+
+	public bool IsEnabled(LogLevel logLevel)
+	{
+		return true;
+	}
+
+	public IDisposable BeginScope<TState>(TState state)
+	{
+		throw new InvalidOperationException("BeginScopeExampleLogger.BeginScope should never be called");
+	}
+}
+
+public sealed class LoggerProviderNoExternalScopeSupport : ILoggerProvider
+{
+	private readonly ConcurrentDictionary<string, BeginScopeThrowsLogger> _loggers = new();
+
+	public void Dispose()
+	{
+	}
+
+	public ILogger CreateLogger(string categoryName)
+	{
+		return _loggers.TryGetValue(categoryName, out var logger)
+			? logger
+			: _loggers.GetOrAdd(categoryName, new BeginScopeThrowsLogger());
+	}
+}

--- a/tests/Rhinobyte.Extensions.Reflection.Tests/Rhinobyte.Extensions.Reflection.Tests.csproj
+++ b/tests/Rhinobyte.Extensions.Reflection.Tests/Rhinobyte.Extensions.Reflection.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Rhinobyte.Extensions.Reflection\Rhinobyte.Extensions.Reflection.csproj" />
-        <ProjectReference Include="..\..\src\Rhinobyte.Extensions.TestTools\Rhinobyte.Extensions.TestTools.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.Reflection\Rhinobyte.Extensions.Reflection.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.TestTools\Rhinobyte.Extensions.TestTools.csproj" />
         <ProjectReference Include="..\ExampleIgnoredAttributeAssembly\ExampleIgnoredAttributeAssembly.csproj" />
         <ProjectReference Include="..\ExampleLibrary1\ExampleLibrary1.csproj" />
     </ItemGroup>

--- a/tests/Rhinobyte.Extensions.SolutionIntegrationTests/Rhinobyte.Extensions.SolutionIntegrationTests.csproj
+++ b/tests/Rhinobyte.Extensions.SolutionIntegrationTests/Rhinobyte.Extensions.SolutionIntegrationTests.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 </Project>

--- a/tests/Rhinobyte.Extensions.TestTools.Tests/Rhinobyte.Extensions.TestTools.Tests.csproj
+++ b/tests/Rhinobyte.Extensions.TestTools.Tests/Rhinobyte.Extensions.TestTools.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Rhinobyte.Extensions.Reflection\Rhinobyte.Extensions.Reflection.csproj" />
-        <ProjectReference Include="..\..\src\Rhinobyte.Extensions.TestTools\Rhinobyte.Extensions.TestTools.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.Reflection\Rhinobyte.Extensions.Reflection.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.TestTools\Rhinobyte.Extensions.TestTools.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**LoggingExtensions**
* Added a new `Rhinobyte.Extensions.Logging` project to the repo/solution
* Added new set of `QueueLoggerProvider` base types that provide re-usable code for implementing custom logging providers that need to push log message processing onto a separate thread.