### PR TITLE
New Rhinobyte.Extensions.CommandLine Project

### DIFF
--- a/Rhinobyte.Extensions.sln
+++ b/Rhinobyte.Extensions.sln
@@ -63,7 +63,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{3BB3D502-2
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rhinobyte.Extensions.Logging", "src\Rhinobyte.Extensions.Logging\Rhinobyte.Extensions.Logging.csproj", "{136AB6AA-B866-4EF0-ABE9-DD41261798E3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rhinobyte.Extensions.Logging.Tests", "tests\Rhinobyte.Extensions.Logging.Tests\Rhinobyte.Extensions.Logging.Tests.csproj", "{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rhinobyte.Extensions.Logging.Tests", "tests\Rhinobyte.Extensions.Logging.Tests\Rhinobyte.Extensions.Logging.Tests.csproj", "{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rhinobyte.Extensions.CommandLine", "src\Rhinobyte.Extensions.CommandLine\Rhinobyte.Extensions.CommandLine.csproj", "{6A9F637D-7032-404B-8A44-86A0D57AF727}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -143,6 +145,12 @@ Global
 		{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}.Release|Any CPU.Build.0 = ReleaseTesting|Any CPU
 		{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}.ReleaseTesting|Any CPU.ActiveCfg = ReleaseTesting|Any CPU
 		{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}.ReleaseTesting|Any CPU.Build.0 = ReleaseTesting|Any CPU
+		{6A9F637D-7032-404B-8A44-86A0D57AF727}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A9F637D-7032-404B-8A44-86A0D57AF727}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A9F637D-7032-404B-8A44-86A0D57AF727}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A9F637D-7032-404B-8A44-86A0D57AF727}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A9F637D-7032-404B-8A44-86A0D57AF727}.ReleaseTesting|Any CPU.ActiveCfg = Release|Any CPU
+		{6A9F637D-7032-404B-8A44-86A0D57AF727}.ReleaseTesting|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -161,6 +169,7 @@ Global
 		{2016443A-45DB-4B47-9C5B-C5F79C05BAE4} = {40E9ED1D-0F68-494D-A657-B75A62645AD8}
 		{136AB6AA-B866-4EF0-ABE9-DD41261798E3} = {BDE5D871-F9C3-405C-9E3F-FE5DE7B26FC6}
 		{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1} = {40E9ED1D-0F68-494D-A657-B75A62645AD8}
+		{6A9F637D-7032-404B-8A44-86A0D57AF727} = {BDE5D871-F9C3-405C-9E3F-FE5DE7B26FC6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A319B09C-E5BD-4E06-94C1-6D8666961326}

--- a/Rhinobyte.Extensions.sln
+++ b/Rhinobyte.Extensions.sln
@@ -65,7 +65,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rhinobyte.Extensions.Loggin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rhinobyte.Extensions.Logging.Tests", "tests\Rhinobyte.Extensions.Logging.Tests\Rhinobyte.Extensions.Logging.Tests.csproj", "{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rhinobyte.Extensions.CommandLine", "src\Rhinobyte.Extensions.CommandLine\Rhinobyte.Extensions.CommandLine.csproj", "{6A9F637D-7032-404B-8A44-86A0D57AF727}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rhinobyte.Extensions.CommandLine", "src\Rhinobyte.Extensions.CommandLine\Rhinobyte.Extensions.CommandLine.csproj", "{6A9F637D-7032-404B-8A44-86A0D57AF727}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rhinobyte.Extensions.CommandLine.Tests", "tests\Rhinobyte.Extensions.CommandLine.Tests\Rhinobyte.Extensions.CommandLine.Tests.csproj", "{713F0EFA-1B5E-471E-BCAB-B1B599B6241B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -151,6 +153,12 @@ Global
 		{6A9F637D-7032-404B-8A44-86A0D57AF727}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6A9F637D-7032-404B-8A44-86A0D57AF727}.ReleaseTesting|Any CPU.ActiveCfg = Release|Any CPU
 		{6A9F637D-7032-404B-8A44-86A0D57AF727}.ReleaseTesting|Any CPU.Build.0 = Release|Any CPU
+		{713F0EFA-1B5E-471E-BCAB-B1B599B6241B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{713F0EFA-1B5E-471E-BCAB-B1B599B6241B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{713F0EFA-1B5E-471E-BCAB-B1B599B6241B}.Release|Any CPU.ActiveCfg = ReleaseTesting|Any CPU
+		{713F0EFA-1B5E-471E-BCAB-B1B599B6241B}.Release|Any CPU.Build.0 = ReleaseTesting|Any CPU
+		{713F0EFA-1B5E-471E-BCAB-B1B599B6241B}.ReleaseTesting|Any CPU.ActiveCfg = ReleaseTesting|Any CPU
+		{713F0EFA-1B5E-471E-BCAB-B1B599B6241B}.ReleaseTesting|Any CPU.Build.0 = ReleaseTesting|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -170,6 +178,7 @@ Global
 		{136AB6AA-B866-4EF0-ABE9-DD41261798E3} = {BDE5D871-F9C3-405C-9E3F-FE5DE7B26FC6}
 		{A3CF8C00-2FE9-405E-8B2E-743DE56CF7C1} = {40E9ED1D-0F68-494D-A657-B75A62645AD8}
 		{6A9F637D-7032-404B-8A44-86A0D57AF727} = {BDE5D871-F9C3-405C-9E3F-FE5DE7B26FC6}
+		{713F0EFA-1B5E-471E-BCAB-B1B599B6241B} = {40E9ED1D-0F68-494D-A657-B75A62645AD8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A319B09C-E5BD-4E06-94C1-6D8666961326}

--- a/devops/create-code-coverage-report
+++ b/devops/create-code-coverage-report
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-allLibraryNames=("Rhinobyte.Extensions.DataAnnotations" "Rhinobyte.Extensions.DependencyInjection" "Rhinobyte.Extensions.Reflection" "Rhinobyte.Extensions.TestTools");
+allLibraryNames=("Rhinobyte.Extensions.CommandLine" "Rhinobyte.Extensions.DataAnnotations" "Rhinobyte.Extensions.DependencyInjection" "Rhinobyte.Extensions.Reflection" "Rhinobyte.Extensions.TestTools");
 allLibraryNamesCount=${#allLibraryNames[@]}
 
 dotnetConfiguration=''
@@ -26,6 +26,7 @@ done;
 
 if [ $testProjectIndex -eq 0 ]; then
 	testProjectNames=(
+		"Rhinobyte.Extensions.CommandLine.Tests" 
 		"Rhinobyte.Extensions.DataAnnotations.Tests" 
 		"Rhinobyte.Extensions.DependencyInjection.Tests" 
 		"Rhinobyte.Extensions.Logging.Tests" 

--- a/solution.props
+++ b/solution.props
@@ -55,13 +55,16 @@
 
 
         <!-- Subproject Package Versions -->
+        <CommandLinePackageVersion>1.0.0-beta.1</CommandLinePackageVersion>
+        <CommandLinePackagePackage_ConsumerDependencyVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(DataAnnotationsPackageVersion)', '(\d+\.\d+)\..+', '$1.0'))</CommandLinePackagePackage_ConsumerDependencyVersion>
+
         <DataAnnotationsPackageVersion>1.0.1</DataAnnotationsPackageVersion>
         <DataAnnotationsPackage_ConsumerDependencyVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(DataAnnotationsPackageVersion)', '(\d+\.\d+)\..+', '$1.0'))</DataAnnotationsPackage_ConsumerDependencyVersion>
 
         <DependencyInjectionPackageVersion>1.0.0</DependencyInjectionPackageVersion>
         <DependencyInjectionPackage_ConsumerDependencyVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(DependencyInjectionPackageVersion)', '(\d+\.\d+)\..+', '$1.0'))</DependencyInjectionPackage_ConsumerDependencyVersion>
 
-        <LoggingPackageVersion>1.0.0-rc.1</LoggingPackageVersion>
+        <LoggingPackageVersion>1.0.0-beta.1</LoggingPackageVersion>
         <LoggingPackage_ConsumerDependencyVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(LoggingPackageVersion)', '(\d+\.\d+)\..+', '$1.0'))</LoggingPackage_ConsumerDependencyVersion>
 
         <ReflectionPackageVersion>1.0.2</ReflectionPackageVersion>

--- a/src/Rhinobyte.Extensions.CommandLine/AdvancedParser.cs
+++ b/src/Rhinobyte.Extensions.CommandLine/AdvancedParser.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
+using System.Reflection;
+
+namespace Rhinobyte.Extensions.CommandLine;
+
+/// <summary>
+/// Implementation of the <see cref="IAdvancedParser{TOptions}"/> build on top of the <see cref="System.CommandLine.Parsing.Parser"/> behaviors
+/// </summary>
+public class AdvancedParser<TOptions> : IAdvancedParser<TOptions>
+	where TOptions : new()
+{
+	private readonly AdvancedParserOptions _parserOptions;
+
+	/// <summary>
+	/// Construct a new instance of the advanced parser
+	/// </summary>
+	public AdvancedParser(
+		AdvancedParserOptions parserOptions)
+	{
+		_parserOptions = parserOptions ?? throw new ArgumentNullException(nameof(parserOptions));
+	}
+
+	/// <summary>
+	/// Create a symbol for the property using reflection to discover the option configuration attribute, if present.
+	/// </summary>
+	protected Symbol? CreateSymbolForProperty(Type optionsType, PropertyInfo propertyInfo)
+	{
+		_ = optionsType ?? throw new ArgumentNullException(nameof(optionsType));
+		_ = propertyInfo ?? throw new ArgumentNullException(nameof(propertyInfo));
+
+		var cliAttribute = propertyInfo.GetCustomAttribute<OptionAttribute>();
+		if (cliAttribute is null)
+		{
+			//_logger?.LogWarningUndecoratedOptionProperty(optionsType, propertyInfo);
+			if (_parserOptions.UndecoratedPropertyBehavior == OptionsModelUndecoratedPropertyBehavior.Ignore)
+				return null;
+
+			if (_parserOptions.UndecoratedPropertyBehavior == OptionsModelUndecoratedPropertyBehavior.Error)
+				throw new InvalidOperationException($"{optionsType.Name} has settable property {propertyInfo.Name} that is missing a {nameof(OptionAttribute)} decorator. If the property should be ignored it can be decorated as [BinderIgnored].");
+		}
+
+		var aliases = cliAttribute?.Aliases ?? new string[] { $"/{propertyInfo.Name}" };
+		return new Option(aliases, argumentType: propertyInfo.PropertyType, arity: cliAttribute?.ArgumentArity ?? default, description: cliAttribute?.Description);
+	}
+
+	/// <summary>
+	/// Create the property to symbol mapping for the specified <paramref name="optionsModelType"/>
+	/// </summary>
+	/// <param name="optionsModelType">The type of the options model to construct the command line symbol mapping for</param>
+	/// <exception cref="ArgumentNullException"></exception>
+	public IReadOnlyDictionary<PropertyInfo, Symbol> CreateSymbolsLookup(Type optionsModelType)
+	{
+		_ = optionsModelType ?? throw new ArgumentNullException(nameof(optionsModelType));
+
+		var modelProperties = optionsModelType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+		var symbolLookup = new Dictionary<PropertyInfo, Symbol>();
+
+		foreach (var propertyInfo in modelProperties)
+		{
+			if (propertyInfo.SetMethod is null)
+				continue;
+
+			var optionSettings = CreateSymbolForProperty(optionsModelType, propertyInfo);
+			if (optionSettings is not null)
+				symbolLookup.Add(propertyInfo, optionSettings);
+		}
+
+		return symbolLookup;
+	}
+
+	/// <summary>
+	/// Construct a new instance of <typeparamref name="TOptions"/> and set the properties using the parse result values from the provided <paramref name="commandLineArguments"/>
+	/// </summary>
+	/// <exception cref="ArgumentNullException"></exception>
+	/// <exception cref="ArgumentException"></exception>
+	/// <exception cref="InvalidOperationException"></exception>
+	public TOptions ParseCommandLineOptions(string[] commandLineArguments)
+	{
+		var symbolLookup = CreateSymbolsLookup(typeof(TOptions));
+		var modelBinder = new ComplexModelBinder<TOptions>(_parserOptions, symbolLookup);
+
+		var optionsParserCommand = new RootCommand();
+		foreach (var symbol in symbolLookup.Values)
+		{
+			switch (symbol)
+			{
+				case Argument argumentSymbol:
+					optionsParserCommand.AddArgument(argumentSymbol);
+					break;
+
+				case Option optionSymbol:
+					optionsParserCommand.AddOption(optionSymbol);
+					break;
+
+				default:
+					throw new ParseOptionsException($"Unexpected symbol type {symbol.GetType().Name} encountered while configuring the {nameof(optionsParserCommand)}");
+			}
+		}
+
+		var parseResult = new CommandLineBuilder(optionsParserCommand)
+			.UseVersionOption()
+			.UseHelp()
+			.Build()
+			.Parse(commandLineArguments);
+
+		if (parseResult is null)
+			throw new InvalidOperationException($"${nameof(Parser)}.{nameof(Parser.Parse)}({nameof(commandLineArguments)} returned a null {nameof(parseResult)} value");
+
+		return parseResult.CreateOptions<TOptions>(modelBinder);
+	}
+}
+
+// TODO: Decide if we want to add back in logging. The ILogger interface is not CLS compliant, at least not the lower 2.2.0 version of Microsoft.Extensions.Logging.Abstractions...
+// TODO: Switch to using the [LoggerMessage(..)] source generator attribute if we start targetting only net6.0+
+//internal static class ParserLoggerExtensions
+//{
+//	private static readonly Action<ILogger, string, string, Exception?> _logWarningUndecoratedOptionProperty =
+//		LoggerMessage.Define<string, string>(
+//			LogLevel.Warning,
+//			new EventId(0, nameof(LogWarningUndecoratedOptionProperty)),
+//			"{OptionsTypeName} has settable property {PropertyName} that is missing a CommandLineOptionAttribute decorator. If the property should be ignored it can be decorated as [CommandLineOption(Ignore = true)]."
+//		);
+
+//	public static void LogWarningUndecoratedOptionProperty(this ILogger logger, Type optionsType, PropertyInfo propertyInfo)
+//		=> _logWarningUndecoratedOptionProperty(logger, optionsType.Name, propertyInfo.Name, null);
+
+//}

--- a/src/Rhinobyte.Extensions.CommandLine/AdvancedParserOptions.cs
+++ b/src/Rhinobyte.Extensions.CommandLine/AdvancedParserOptions.cs
@@ -1,0 +1,18 @@
+﻿namespace Rhinobyte.Extensions.CommandLine;
+
+/// <summary>
+/// Configuration options for the <see cref="ComplexModelBinder{TOptions}"/> behavior
+/// </summary>
+public class AdvancedParserOptions
+{
+	/// <summary>
+	/// When true the <see cref="ComplexModelBinder{TOptions}"/> will throw if the underlying <see cref="System.CommandLine.Parsing.ParseResult"/> has any errors
+	/// </summary>
+	public bool ThrowOnOptionsParserErrors { get; set; }
+
+	/// <summary>
+	/// The behavior for the parser to apply for any settable properties on the TOptions type that are missing an explicit
+	/// <see cref="OptionAttribute"/> decorator.
+	/// </summary>
+	public OptionsModelUndecoratedPropertyBehavior UndecoratedPropertyBehavior { get; set; }
+}

--- a/src/Rhinobyte.Extensions.CommandLine/BinderIgnoredAttribute.cs
+++ b/src/Rhinobyte.Extensions.CommandLine/BinderIgnoredAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Rhinobyte.Extensions.CommandLine;
+
+/// <summary>
+/// Attribute used to decorate model properties that should be ignored by the advanced parser/binder
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class BinderIgnoredAttribute : Attribute
+{
+}

--- a/src/Rhinobyte.Extensions.CommandLine/ComplexModelBinder.cs
+++ b/src/Rhinobyte.Extensions.CommandLine/ComplexModelBinder.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Binding;
+using System.Linq;
+using System.Reflection;
+
+namespace Rhinobyte.Extensions.CommandLine;
+
+/// <summary>
+/// Custom binder implementation for the System.CommandLine parser so we can support binding complex models with attributes decorated and/or default behavior fallbacks based on member names
+/// </summary>
+/// <typeparam name="TOptions"></typeparam>
+public class ComplexModelBinder<TOptions> : BinderBase<TOptions>
+	where TOptions : new()
+{
+	private readonly AdvancedParserOptions _parserOptions;
+	private readonly IReadOnlyDictionary<PropertyInfo, Symbol> _symbolLookup;
+
+	/// <summary>
+	/// Construct a new binder instance
+	/// </summary>
+	/// <param name="parserOptions">The options for configurable behaviors</param>
+	/// <param name="symbolLookup">The dictionary used to lookup the parser symbol for a <see cref="PropertyInfo"/> from the <typeparamref name="TOptions"/> type</param>
+	/// <exception cref="ArgumentNullException">Thrown if either of the required <paramref name="parserOptions"/> or <paramref name="symbolLookup"/> are null</exception>
+	public ComplexModelBinder(
+		AdvancedParserOptions parserOptions,
+		IReadOnlyDictionary<PropertyInfo, Symbol> symbolLookup)
+	{
+		_parserOptions = parserOptions ?? throw new ArgumentNullException(nameof(parserOptions));
+		_symbolLookup = symbolLookup ?? throw new ArgumentNullException(nameof(symbolLookup));
+	}
+
+	/// <summary>
+	/// Method to expose protected <see cref="GetBoundValue(BindingContext)"/> implementation publicly on the binder
+	/// </summary>
+	public TOptions CreateOptions(BindingContext bindingContext) => GetBoundValue(bindingContext);
+
+	/// <inheritdoc/>
+	protected override TOptions GetBoundValue(BindingContext bindingContext)
+	{
+		_ = bindingContext ?? throw new ArgumentNullException(nameof(bindingContext));
+
+		var optionsType = typeof(TOptions);
+		var optionsProperties = optionsType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+		var missingOptions = new List<string>();
+
+		var boundOptions = new TOptions();
+		var parseResult = bindingContext.ParseResult;
+		foreach (var propertyInfo in optionsProperties)
+		{
+			if (!_symbolLookup.TryGetValue(propertyInfo, out var symbol))
+				continue;
+
+			var isRequired = propertyInfo.GetCustomAttributes()?.Any(attribute => attribute.GetType()?.FullName == "System.ComponentModel.DataAnnotations.RequiredAttribute") == true;
+			if (isRequired && parseResult.FindResultFor(symbol) is null)
+			{
+				var symbolAliases = symbol is IdentifierSymbol identifierSymbol
+					? $"'{string.Join("', '", identifierSymbol.Aliases)}' "
+					: string.Empty;
+				missingOptions.Add($"  {symbolAliases}[Property: {propertyInfo.Name}]");
+				continue;
+			}
+
+			var propertyValue = symbol switch
+			{
+				Argument argumentSymbol => parseResult.GetValueForArgument(argumentSymbol),
+				Option optionSymbol => parseResult.GetValueForOption(optionSymbol),
+				_ => throw new ParseOptionsException($"Unexpected symbol type {symbol.GetType().Name} for property {propertyInfo.Name}")
+			};
+
+			propertyInfo.SetValue(boundOptions, propertyValue);
+		}
+
+		if (bindingContext.ParseResult.Errors.Count > 0)
+		{
+			var combinedErrors = $"{Environment.NewLine}{string.Join(Environment.NewLine, bindingContext.ParseResult.Errors)}";
+
+			if (_parserOptions.ThrowOnOptionsParserErrors)
+				throw new ParseOptionsException($"The command line options parse result contains errors:{combinedErrors}");
+		}
+
+		if (missingOptions.Count > 0)
+			throw new ParseOptionsException($"The following required options have not been provided:{Environment.NewLine}{string.Join(Environment.NewLine, missingOptions)}{Environment.NewLine}");
+
+		return boundOptions;
+	}
+}
+

--- a/src/Rhinobyte.Extensions.CommandLine/ComplexModelBinder.cs
+++ b/src/Rhinobyte.Extensions.CommandLine/ComplexModelBinder.cs
@@ -73,12 +73,10 @@ public class ComplexModelBinder<TOptions> : BinderBase<TOptions>
 			propertyInfo.SetValue(boundOptions, propertyValue);
 		}
 
-		if (bindingContext.ParseResult.Errors.Count > 0)
+		if (bindingContext.ParseResult.Errors.Count > 0 && _parserOptions.ThrowOnOptionsParserErrors)
 		{
 			var combinedErrors = $"{Environment.NewLine}{string.Join(Environment.NewLine, bindingContext.ParseResult.Errors)}";
-
-			if (_parserOptions.ThrowOnOptionsParserErrors)
-				throw new ParseOptionsException($"The command line options parse result contains errors:{combinedErrors}");
+			throw new ParseOptionsException($"The command line options parse result contains errors:{combinedErrors}");
 		}
 
 		if (missingOptions.Count > 0)

--- a/src/Rhinobyte.Extensions.CommandLine/IAdvancedParser.cs
+++ b/src/Rhinobyte.Extensions.CommandLine/IAdvancedParser.cs
@@ -1,0 +1,14 @@
+﻿namespace Rhinobyte.Extensions.CommandLine;
+
+/// <summary>
+/// Signature for a parser that will parse the provided arguments and bind them to the specified options type.
+/// </summary>
+public interface IAdvancedParser<TOptions>
+	where TOptions : new()
+{
+	/// <summary>
+	/// Parse the provided <paramref name="commandLineArguments"/> and bind the parsed values to a new instance of <typeparamref name="TOptions"/> 
+	/// </summary>
+	TOptions ParseCommandLineOptions(string[] commandLineArguments);
+}
+

--- a/src/Rhinobyte.Extensions.CommandLine/OptionAttribute.cs
+++ b/src/Rhinobyte.Extensions.CommandLine/OptionAttribute.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.CommandLine;
+
+namespace Rhinobyte.Extensions.CommandLine;
+
+/// <summary>
+/// Attribute for configuring command line option values that will be used to bind to the decorated property
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class OptionAttribute : Attribute
+{
+	/// <summary>
+	/// The aliases for the <see cref="System.CommandLine.Option{T}"/>
+	/// </summary>
+	public string[]? Aliases { get; set; }
+
+	/// <summary>
+	/// The arity for the option arguments
+	/// </summary>
+	public ArgumentArity ArgumentArity { get; set; }
+
+	/// <summary>
+	/// An optional value for the <see cref="System.CommandLine.Symbol.Description"/>
+	/// </summary>
+	public string? Description { get; set; }
+}

--- a/src/Rhinobyte.Extensions.CommandLine/OptionsModelUndecoratedPropertyBehavior.cs
+++ b/src/Rhinobyte.Extensions.CommandLine/OptionsModelUndecoratedPropertyBehavior.cs
@@ -1,0 +1,25 @@
+﻿using System.Reflection;
+
+namespace Rhinobyte.Extensions.CommandLine;
+
+
+/// <summary>
+/// The behavior to apply 
+/// </summary>
+public enum OptionsModelUndecoratedPropertyBehavior
+{
+	/// <summary>
+	/// The parser will try create an option symbol using the <see cref="MemberInfo.Name"/>
+	/// </summary>
+	Default = 0,
+
+	/// <summary>
+	/// The parser will throw if a settable property does not have either an explicit symbol decorator or an explicit <see cref="BinderIgnoredAttribute"/> decorator
+	/// </summary>
+	Error = 1,
+
+	/// <summary>
+	/// The parser will ignore the settable property if it does not have an explicit symbol decorator
+	/// </summary>
+	Ignore = 2
+}

--- a/src/Rhinobyte.Extensions.CommandLine/ParseOptionsException.cs
+++ b/src/Rhinobyte.Extensions.CommandLine/ParseOptionsException.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace Rhinobyte.Extensions.CommandLine;
+
+/// <summary>
+/// Exception type thrown when errors occur parsing the command line options or binding the parse results to the complex model members
+/// </summary>
+[Serializable]
+public class ParseOptionsException : InvalidOperationException
+{
+	/// <summary>
+	/// Construct a new instance of the exception
+	/// </summary>
+	public ParseOptionsException()
+		: base()
+	{
+	}
+
+	/// <summary>
+	/// Construct a new instance of the exception with the provided message
+	/// </summary>
+	public ParseOptionsException(string message)
+		: base(message)
+	{
+	}
+
+	/// <summary>
+	/// Construct a new instance of the exception with the provided message and inner exception
+	/// </summary>
+	public ParseOptionsException(string message, Exception innerException)
+		: base(message, innerException)
+	{
+	}
+
+	/// <summary>
+	/// Pass through implementation of the seralization constructor for <see cref="System.Runtime.Serialization.ISerializable"/> support
+	/// </summary>
+	protected ParseOptionsException(
+		System.Runtime.Serialization.SerializationInfo serializationInfo,
+		System.Runtime.Serialization.StreamingContext streamingContext)
+		: base(serializationInfo, streamingContext)
+	{
+
+	}
+}
+
+

--- a/src/Rhinobyte.Extensions.CommandLine/ParseResultExtensions.cs
+++ b/src/Rhinobyte.Extensions.CommandLine/ParseResultExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+
+namespace Rhinobyte.Extensions.CommandLine;
+
+/// <summary>
+/// Convenience extension methods to allow for fluent like call chaining against <see cref="ParseResult"/> type
+/// </summary>
+public static class ParseResultExtensions
+{
+
+	/// <summary>
+	/// Create and return a <typeparamref name="TOptions"/> instance using <paramref name="modelBinder"/> to bind the values from the <paramref name="parseResult"/>
+	/// </summary>
+	/// <exception cref="ArgumentNullException"></exception>
+	public static TOptions CreateOptions<TOptions>(this ParseResult parseResult, ComplexModelBinder<TOptions> modelBinder, IConsole? console = null)
+		where TOptions : new()
+	{
+		_ = parseResult ?? throw new ArgumentNullException(nameof(parseResult));
+		_ = modelBinder ?? throw new ArgumentNullException(nameof(modelBinder));
+
+		var bindingContext = new InvocationContext(parseResult, console: console).BindingContext;
+		return modelBinder.CreateOptions(bindingContext);
+	}
+}

--- a/src/Rhinobyte.Extensions.CommandLine/README.md
+++ b/src/Rhinobyte.Extensions.CommandLine/README.md
@@ -1,0 +1,7 @@
+# Rhinobyte.Extensions.CommandLine
+
+[![NuGet version (Rhinobyte.Extensions.CommandLine)](https://img.shields.io/nuget/v/Rhinobyte.Extensions.CommandLine.svg?style=flat)](https://www.nuget.org/packages/Rhinobyte.Extensions.CommandLine/)
+
+This library contains extensions built on top of the dotnet/command-line-api (System.CommandLine)
+
+The extensions include support for complex model binding from the command line arguments using property attribute decorators

--- a/src/Rhinobyte.Extensions.CommandLine/Rhinobyte.Extensions.CommandLine.csproj
+++ b/src/Rhinobyte.Extensions.CommandLine/Rhinobyte.Extensions.CommandLine.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+        <Configurations>Debug;Release;ReleaseTesting</Configurations>
+
+        <!-- VERSION VALUES -->
+        <PackageVersion>$(CommandLinePackageVersion)</PackageVersion>
+        <AssemblyVersion>$(PackageVersion).0</AssemblyVersion>
+        <FileVersion>$(PackageVersion).0</FileVersion>
+        <InformationalVersion>$(PackageVersion)</InformationalVersion>
+        <Version>$(PackageVersion)</Version>
+
+        <PackageId>Rhinobyte.Extensions.CommandLine</PackageId>
+        <AssemblyName>$(PackageId)</AssemblyName>
+        <RootNamespace>$(PackageId)</RootNamespace>
+        <Title>$(PackageId)</Title>
+        <PackageTags>commands command_line parsing options</PackageTags>
+
+        <ReleaseNotesTextFilePath>$(MSBuildProjectDirectory)\RELEASE-NOTES.txt</ReleaseNotesTextFilePath>
+        <Summary>Extensions to the dotnet System.CommandLine packages</Summary>
+        <Description>
+            $(Summary)
+        </Description>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
+    </ItemGroup>
+
+    <!-- Prior to netcoreapp3.1 the System.Threading.Channels package is needed -->
+    <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.1'))">
+        <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Rhinobyte.Extensions.CommandLine.Tests/AdvancedParserTests.cs
+++ b/tests/Rhinobyte.Extensions.CommandLine.Tests/AdvancedParserTests.cs
@@ -1,0 +1,97 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.ComponentModel.DataAnnotations;
+
+using static FluentAssertions.FluentActions;
+
+namespace Rhinobyte.Extensions.CommandLine.Tests;
+
+[TestClass]
+public class AdvancedParserTests
+{
+	[TestMethod]
+	public void ParseCommandLineOptions_does_not_throw_for_unknown_args_when_ThrowOnOptionsParserErrors_is_false()
+	{
+		var advancedParserOptions = new AdvancedParserOptions();
+		var parser = new AdvancedParser<TestOptions>(advancedParserOptions);
+
+		var testArguments = new string[] { "/intone=1", "--int-two", "5", "/IsEnabled=true", "--string-option-one", "Some String", "--unknown-one", "unknownonevalue", "--unknown-two", "-u", "/unknownfour", "unknownfourvalue", "/unknownfive=555" };
+		var parsedOptions = parser.ParseCommandLineOptions(testArguments);
+
+		parsedOptions.Should().NotBeNull().And.BeOfType<TestOptions>();
+
+		parsedOptions.IntegerOptionOne.Should().Be(1);
+		parsedOptions.IntegerOptionTwo.Should().Be(5);
+		parsedOptions.IsEnabled.Should().BeTrue();
+		parsedOptions.StringOptionOne.Should().Be("Some String");
+		parsedOptions.StringOptionTwo.Should().BeNull();
+	}
+
+	[TestMethod]
+	public void ParseCommandLineOptions_returns_the_expected_result()
+	{
+		var advancedParserOptions = new AdvancedParserOptions();
+		var parser = new AdvancedParser<TestOptions>(advancedParserOptions);
+
+		var testArguments = new string[] { "/intone=1", "--int-two", "5", "/IsEnabled=true", "--string-option-one", "Some String" };
+		var parsedOptions = parser.ParseCommandLineOptions(testArguments);
+
+		parsedOptions.Should().NotBeNull().And.BeOfType<TestOptions>();
+
+		parsedOptions.IntegerOptionOne.Should().Be(1);
+		parsedOptions.IntegerOptionTwo.Should().Be(5);
+		parsedOptions.IsEnabled.Should().BeTrue();
+		parsedOptions.StringOptionOne.Should().Be("Some String");
+		parsedOptions.StringOptionTwo.Should().BeNull();
+	}
+
+	[TestMethod]
+	public void ParseCommandLineOptions_throws_for_unknown_args_when_ThrowOnOptionsParserErrors_is_true()
+	{
+		var advancedParserOptions = new AdvancedParserOptions { ThrowOnOptionsParserErrors = true };
+		var parser = new AdvancedParser<TestOptions>(advancedParserOptions);
+
+		var testArguments = new string[] { "/intone=1", "--int-two", "5", "/IsEnabled=true", "--string-option-one", "Some String", "--unknown-one", "unknownonevalue", "--unknown-two", "-u", "/unknownfour", "unknownfourvalue", "/unknownfive=555" };
+		Invoking(() => parser.ParseCommandLineOptions(testArguments))
+			.Should()
+			.Throw<ParseOptionsException>()
+			.WithMessage("The command line options parse result contains errors:*");
+	}
+
+	[TestMethod]
+	public void ParseCommandLineOptions_throws_when_a_required_option_is_not_set()
+	{
+		var advancedParserOptions = new AdvancedParserOptions();
+		var parser = new AdvancedParser<TestOptions>(advancedParserOptions);
+
+		var testArguments = new string[] { "/intone=1", "--int-two", "5", "/IsEnabled=true" };
+		Invoking(() => parser.ParseCommandLineOptions(testArguments))
+			.Should()
+			.Throw<ParseOptionsException>()
+			.WithMessage("The following required options have not been provided:*");
+	}
+
+	public class TestOptions
+	{
+		[Required]
+		[Option(Aliases = new string[] { "--int-one", "/intone" }, Description = "[Required] Integer option one")]
+		public int IntegerOptionOne { get; set; }
+
+		[Option(Aliases = new string[] { "--int-two" }, Description = "[Optional] Integer option two")]
+		public int IntegerOptionTwo { get; set; }
+
+		public bool IsEnabled { get; set; }
+
+		public bool? NullableBoolOption { get; set; }
+
+		[Required]
+		[Option(Aliases = new string[] { "--string-option-one", "-s", "/stringoptionone" }, Description = "[Required] String option one")]
+		public string StringOptionOne { get; set; } = string.Empty;
+
+		[Option(Aliases = new string[] { "--string-option-two", "-t", "/stringoptiontwo" }, Description = "[Optional] String option two")]
+		public string StringOptionTwo { get; set; } = string.Empty;
+
+
+		public string NotSettable => string.Empty;
+	}
+}

--- a/tests/Rhinobyte.Extensions.CommandLine.Tests/Rhinobyte.Extensions.CommandLine.Tests.csproj
+++ b/tests/Rhinobyte.Extensions.CommandLine.Tests/Rhinobyte.Extensions.CommandLine.Tests.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <ItemGroup>
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.CommandLine\Rhinobyte.Extensions.CommandLine.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\Rhinobyte.Extensions.TestTools\Rhinobyte.Extensions.TestTools.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
**CommandLineExtensions**
* Added new `Rhinobyte.Extensions.CommandLine` project as a beta version
* Added new parser and binder extension types to allow binding a complex model from command line arguments using attribute based binding configuration
* Added new `Rhinobyte.Extensions.CommandLine.Tests` project with some basic test coverage over the advanced parser logic